### PR TITLE
Verifiable Anchor build for Community version

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,10 @@
+anchor_version = "0.24.2"
+
 [programs.localnet]
 timelock = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[programs.mainnet]
+timelock = "8e72pYCDaxu3GqMfeQ5r8wFgoZSYk6oua1Qo9XpsZjX"
 
 [registry]
 url = "https://anchor.projectserum.com"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14189df19df7f3977a7ea236ccae6cdc40855ab5baf1ab2796a091ef5c490d1"
+
+[[package]]
 name = "spl-associated-token-account"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1221,7 @@ version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "solana-security-txt",
  "streamflow-timelock",
 ]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+Even though this is a free and open-source software given to the community, we value security and correctness highly, and as such we want to introduce a bug-bounty program to incentivize the community to help us by auditing the code.
+
+Program is split into 2 parts:
+- [Core protocol implementation](https://github.com/streamflow-finance/timelock-crate/tree/community)
+- [Anchor wrapper](https://github.com/streamflow-finance/js-sdk/tree/community)
+
+This security policy covers only the smart contracts, not the potential UI bugs. Also any defects found in the forked versions, not deployed by Streamflow will not be covered, as we will not be able to act upon them.
+
+## Reporting
+Email us at security@streamflow.finance with a detailed description of a vulnerability. This report must come with at least a crude proof of concept, showcasing the attack. 
+
+## Rewards
+
+Rewards are distributed according to the following classifications:
+
+### Severity critical
+
+- Loss of user funds staked (principal) by freezing or theft
+- Unauthorized claims of funds
+
+10% of value at risk, up to $500,000 USD
+
+### Severity high
+
+- Permanent freezing of unlocked funds
+- Temporary freezing of unlocked funds for at least 24 hour
+
+Up to $20,000 USD
+
+### Severity medium
+
+- Block stuffing for profit
+- Griefing (e.g. no profit motive for an attacker, but damage to the users or the protocol)
+- Theft of gas
+- Unbounded gas consumption 
+
+Up to $5,000 USD
+
+This bounty is only paid out if details about the security issues have not been provided to third parties before a fix has been introduced and verified. Furthermore, the reporter is in no way allowed to exploit the issue without our explicit consent. Actual prize size is determined based on a combination of factors including but not limited to severity, value at risk, and likelihood of being exploited.
+
+Payouts are done in vesting STRM on Solana.
+
+## Out of Scope and Rules
+
+The following vulnerabilities are excluded from the rewards for this bug bounty program:
+- Attacks that the reporter has already exploited themselves, leading to damage
+- Attacks requiring access to leaked keys/credentials
+- Attacks requiring access to privileged addresses (treasury, organization’s private deploy keys)
+
+The following activities are prohibited by this bug bounty program:
+- Any testing with mainnet contracts; all testing should be done on devnet or private testnets
+- Attempting phishing or other social engineering attacks against our employees and/or customers
+- Any testing with third party systems and applications (e.g. browser extensions) as well as websites (e.g. SSO providers, advertising networks)
+- Any denial of service attacks
+- Automated testing of services that generates significant amounts of traffic
+- Public disclosure of an unpatched vulnerability in an embargoed bounty

--- a/programs/timelock/Cargo.toml
+++ b/programs/timelock/Cargo.toml
@@ -18,3 +18,4 @@ default = []
 anchor-lang = "0.17.0"
 anchor-spl = "0.17.0"
 streamflow-timelock = "0.3.2"
+solana-security-txt = "1.0.1"

--- a/programs/timelock/src/lib.rs
+++ b/programs/timelock/src/lib.rs
@@ -1,9 +1,20 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use streamflow_timelock::{
-    state::{CancelAccounts, InitializeAccounts, StreamInstruction, TransferAccounts, WithdrawAccounts}
+use solana_security_txt::security_txt;
+use streamflow_timelock::state::{
+    CancelAccounts, InitializeAccounts, StreamInstruction, TransferAccounts, WithdrawAccounts,
 };
+
+security_txt! {
+    name: "timelock",
+    project_url: "https://streamflow.finance/",
+    contacts: "email:security@streamflow.finance,discord:https://discord.com/invite/ZC7URcQyM7",
+    policy: "https://github.com/streamflow-finance/js-sdk/blob/community/SECURITY.md",
+    preferred_languages: "en",
+    source_code: "https://github.com/streamflow-finance/timelock-crate/tree/community",
+    auditors: "opcodes"
+}
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 


### PR DESCRIPTION
- Anchor version is fixed to a 0.24 since security-txt requires us to use a newer version of rust compiler.
- Added address of program on the mainnet to anchor configuration
- Added security policy

