### PR TITLE
fix: fix ContractError prototype

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.9.6",
+  "version": "5.9.7",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/stream/common/types.ts
+++ b/packages/stream/common/types.ts
@@ -289,15 +289,9 @@ export class ContractError extends Error {
    */
   constructor(error: Error, code?: string | null) {
     super(error.message); // Call the base class constructor with the error message
-    this.name = "ContractError"; // Set the name property
     this.contractErrorCode = code ?? null;
-
     // Copy properties from the original error
-    Object.getOwnPropertyNames(error).forEach((key) => {
-      (this as any)[key] = (error as any)[key];
-    });
-
-    // If you want to capture the stack trace:
-    this.stack = error.stack;
+    Object.setPrototypeOf(this, ContractError.prototype);
+    this.name = "ContractError"; // Set the name property
   }
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "main": "dist/index.js",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",


### PR DESCRIPTION
The prototype of ContractError should be set appropriately. Otherwise, it is impossible to distinguish these errors from others with `instanceof`