### PR TITLE
STREAM-1172: optimise solana batching

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.10.1",
+  "version": "5.10.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "5.10.1",
+  "version": "5.10.2",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",


### PR DESCRIPTION
- fetch blockhash only once in Solana createMultiple to optimise batching as ideally all transactions in a batch should use the same block