### PR TITLE
optimise tx confirmation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.11.3",
+  "version": "5.11.4",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "5.11.3",
+  "version": "5.11.4",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -146,7 +146,8 @@ export default class SolanaStreamClient extends BaseStreamClient {
       this.connection,
       ixs,
       extParams.sender.publicKey,
-      this.getCommitment(),
+      undefined,
+
       metadata
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.sender, tx, hash);
@@ -288,7 +289,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
       this.connection,
       ixs,
       extParams.sender.publicKey,
-      this.getCommitment(),
+      undefined,
       metadata
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.sender, tx, hash);
@@ -457,9 +458,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
       instructionsBatch.push({ ixs, metadata, recipient: recipientData.recipient });
     }
 
-    const commitment =
-      typeof this.commitment == "string" ? this.commitment : this.commitment.commitment;
-    const hash = await this.connection.getLatestBlockhash(commitment);
+    const hash = await this.connection.getLatestBlockhash();
 
     for (const { ixs, metadata, recipient } of instructionsBatch) {
       const tx = new Transaction({
@@ -554,8 +553,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     const { tx, hash } = await prepareTransaction(
       this.connection,
       ixs,
-      extParams.invoker.publicKey,
-      this.getCommitment()
+      extParams.invoker.publicKey
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.invoker, tx, hash);
 
@@ -619,8 +617,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     const { tx, hash } = await prepareTransaction(
       this.connection,
       ixs,
-      extParams.invoker.publicKey,
-      this.getCommitment()
+      extParams.invoker.publicKey
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.invoker, tx, hash);
 
@@ -691,8 +688,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     const { tx, hash } = await prepareTransaction(
       this.connection,
       ixs,
-      extParams.invoker.publicKey,
-      this.getCommitment()
+      extParams.invoker.publicKey
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.invoker, tx, hash);
 
@@ -756,8 +752,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     const { tx, hash } = await prepareTransaction(
       this.connection,
       ixs,
-      extParams.invoker.publicKey,
-      this.getCommitment()
+      extParams.invoker.publicKey
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.invoker, tx, hash);
 
@@ -884,8 +879,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     const { tx, hash } = await prepareTransaction(
       this.connection,
       ixs,
-      extParams.invoker.publicKey,
-      this.getCommitment()
+      extParams.invoker.publicKey
     );
     const signature = await signAndExecuteTransaction(this.connection, extParams.invoker, tx, hash);
 

--- a/packages/stream/solana/utils.ts
+++ b/packages/stream/solana/utils.ts
@@ -126,7 +126,13 @@ export function isSignerKeypair(
 }
 
 /**
- * Creates a Transaction with given instructions and optionally signs it
+ * Creates a Transaction with given instructions and optionally signs it.
+ * Be careful when passing `commitment` as for `confirmed` blockhash it always returns blockheight + 300 in `lastValidBlockHeight`
+ * And if you use this blockheight to confirm the transaction it could happen so that transaction is successfully executed
+ * But because `confirmTransaction` waits for only a minute it considers tx as expired as it could be that 300 blocks won't pass in a minute
+ * https://solana.stackexchange.com/questions/6238/why-is-lastvalidblockheight-300-blocks-ahead-than-current-blockheight-if-hashes
+ * https://solana.com/docs/core/transactions/retry
+ * It might be better to rely on `commitment` level that you pass to `Connection` instance of Solana client as it will be used when fetching blockheight on transaction confirmation
  * @param connection - Solana client connection
  * @param ixs - Instructions to add to the Transaction
  * @param payer - PublicKey of payer


### PR DESCRIPTION
do not pass commitment to prepareTransaction as we should be able to rely on commitment that we have in our RPC Connection instance to confirm a transaction;