### PR TITLE
Optimise tx confirmation further

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.2",
+  "version": "6.0.3",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -50,3 +50,11 @@ export async function handleContractError<T>(
     throw err;
   }
 }
+
+/**
+ * Pause async function execution for given amount of milliseconds
+ * @param ms millisecond to sleep for
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/stream/solana/utils.ts
+++ b/packages/stream/solana/utils.ts
@@ -1,12 +1,6 @@
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
-import {
-  BlockheightBasedTransactionConfirmationStrategy,
-  Connection,
-  Keypair,
-  PublicKey,
-  sendAndConfirmRawTransaction,
-} from "@solana/web3.js";
-import { isSignerKeypair, isSignerWallet } from "@streamflow/common/solana";
+import { BlockheightBasedTransactionConfirmationStrategy, Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { executeTransaction, isSignerKeypair, isSignerWallet } from "@streamflow/common/solana";
 import BN from "bn.js";
 import bs58 from "bs58";
 
@@ -107,7 +101,6 @@ export async function sendAndConfirmStreamRawTransaction(
   batchItem: BatchItem,
 ): Promise<BatchItemResult> {
   try {
-    const rawTx = batchItem.tx.serialize();
     const { lastValidBlockHeight, signature, recentBlockhash } = batchItem.tx;
     if (!lastValidBlockHeight || !signature || !recentBlockhash)
       throw { recipient: batchItem.recipient, error: "no recent blockhash" };
@@ -117,7 +110,7 @@ export async function sendAndConfirmStreamRawTransaction(
       signature: bs58.encode(signature),
       blockhash: recentBlockhash,
     };
-    const completedTxSignature = await sendAndConfirmRawTransaction(connection, rawTx, confirmationStrategy);
+    const completedTxSignature = await executeTransaction(connection, batchItem.tx, confirmationStrategy);
     return { ...batchItem, signature: completedTxSignature };
   } catch (error: any) {
     throw {


### PR DESCRIPTION
- solana: trigger one last status check manually in case blockheight has expired on tx confirmation