### PR TITLE
Fix mint account isWritable to true when withdraw

### DIFF
--- a/packages/stream/solana/instructions.ts
+++ b/packages/stream/solana/instructions.ts
@@ -259,7 +259,7 @@ export const withdrawStreamInstruction = (
     { pubkey: streamflowTreasuryTokens, isSigner: false, isWritable: true },
     { pubkey: partner, isSigner: false, isWritable: true },
     { pubkey: partnerTokens, isSigner: false, isWritable: true },
-    { pubkey: mint, isSigner: false, isWritable: false },
+    { pubkey: mint, isSigner: false, isWritable: true },
     { pubkey: tokenProgram, isSigner: false, isWritable: false },
   ];
 


### PR DESCRIPTION
- In devnet cannot run withdraw function from sdk cause of mint account:
![Screenshot 2024-05-20 at 11 54 01](https://github.com/streamflow-finance/js-sdk/assets/56625712/bb001617-005c-40c2-b9dd-179a29110c2e)

- Here are txn: https://explorer.solana.com/tx/59G3CjrpwfJN211V2zVvUpq2kF9An1vL6wdeSfEFxKnHcNz4fGkv13KbTR3YUkrMLfGCNXydRRQs8hNsNg78wiV6?cluster=devnet

- Fix isWritable of mint account from withdrawStreamInstruction to true