### PR TITLE
take the func getMintAndProgram outside

### DIFF
--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -440,6 +440,9 @@ export default class SolanaStreamClient extends BaseStreamClient {
     }[] = [];
     metadataPubKeys = metadataPubKeys || [];
 
+    const { tokenProgramId } = await getMintAndProgram(this.connection, data.tokenId);
+
+
     for (let i = 0; i < recipients.length; i++) {
       const recipientData = recipients[i];
       const { ixs, metadata, metadataPubKey } = await this.prepareStreamInstructions(recipientData, data, {
@@ -447,7 +450,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
         metadataPubKeys: metadataPubKeys[i] ? [metadataPubKeys[i]] : undefined,
         computePrice,
         computeLimit,
-      });
+      }, tokenProgramId);
 
       metadataToRecipient[metadataPubKey.toBase58()] = recipientData;
 
@@ -975,6 +978,7 @@ export default class SolanaStreamClient extends BaseStreamClient {
     recipient: IRecipient,
     streamParams: IStreamConfig,
     extParams: ICreateStreamSolanaExt,
+    tokenProgramId: PublicKey
   ): Promise<{
     ixs: TransactionInstruction[];
     metadata: Keypair | undefined;
@@ -1013,7 +1017,6 @@ export default class SolanaStreamClient extends BaseStreamClient {
       this.programId,
     );
 
-    const { tokenProgramId } = await getMintAndProgram(this.connection, mintPublicKey);
     const senderTokens = await ata(mintPublicKey, sender.publicKey, tokenProgramId);
     const recipientTokens = await ata(mintPublicKey, recipientPublicKey, tokenProgramId);
     const streamflowTreasuryTokens = await ata(mintPublicKey, STREAMFLOW_TREASURY_PUBLIC_KEY, tokenProgramId);


### PR DESCRIPTION
- Premature close error comes up when i create multiple streams with over 25 recipients. After that, I checked the error, it came from calling the getAccountInfo method too many times, but before the call was completed, the connection to the RPC was broken.
- When I look at the code it happens at this line in `prepareStreamInstructions` function:
`const { tokenProgramId } = await getMintAndProgram(this.connection, mintPublicKey);`

- I'm wondering if we `createMultiple` each stream have the same mint token address, so why we need run `getMintAndProgram` multiple time, so i bring `getMintAndProgram` outsite `creaateMultiople` and pass `tokenProgramId` to `prepareStreamInstructions`

- And i think it's solve this issue: [link](https://github.com/solana-labs/solana-web3.js/issues/1255)