### PR TITLE
STREAM-1597: account for transfer fees when creating Airdrops

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.3.7",
+  "version": "6.3.8",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/distributor/solana/client.ts
+++ b/packages/distributor/solana/client.ts
@@ -55,7 +55,7 @@ import {
   getClaimantStatusPda,
   getDistributorPda,
   getEventAuthorityPda,
-  wrappedSignAndExecuteTransaction
+  wrappedSignAndExecuteTransaction,
 } from "./utils";
 
 interface IInitOptions {

--- a/packages/distributor/solana/constants.ts
+++ b/packages/distributor/solana/constants.ts
@@ -1,5 +1,7 @@
 import { ICluster } from "@streamflow/common";
 
+export const ONE_IN_BASIS_POINTS = BigInt(10_000);
+
 export const DISTRIBUTOR_PROGRAM_ID = {
   [ICluster.Devnet]: "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N",
   [ICluster.Mainnet]: "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N",

--- a/packages/distributor/solana/utils.ts
+++ b/packages/distributor/solana/utils.ts
@@ -1,11 +1,13 @@
+import { TransferFeeConfig } from "@solana/spl-token";
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
 import { Connection, Keypair, PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { ContractError } from "@streamflow/common";
 import { ConfirmationParams, signAndExecuteTransaction, ThrottleParams } from "@streamflow/common/solana";
 
 import { fromTxError } from "./generated/errors";
+import { ONE_IN_BASIS_POINTS } from "./constants";
 
-export const ceilN = (n: bigint, d: bigint): bigint => n / d + (n % d ? BigInt(1) : BigInt(0));
+export const divCeilN = (n: bigint, d: bigint): bigint => n / d + (n % d ? BigInt(1) : BigInt(0));
 
 export function getDistributorPda(programId: PublicKey, mint: PublicKey, version: number): PublicKey {
   // Constructing the seed for the PDA
@@ -53,4 +55,29 @@ export async function wrappedSignAndExecuteTransaction(
     }
     throw err;
   }
+}
+
+export async function calculateAmountWithTransferFees(
+  connection: Connection,
+  transferFeeConfig: TransferFeeConfig,
+  transferAmount: bigint,
+): Promise<{ transferAmount: bigint; feeCharged: bigint }> {
+  const epoch = await connection.getEpochInfo();
+  const transferFee =
+    epoch.epoch >= transferFeeConfig.newerTransferFee.epoch
+      ? transferFeeConfig.newerTransferFee
+      : transferFeeConfig.olderTransferFee;
+  const transferFeeBasisPoints = BigInt(transferFee.transferFeeBasisPoints);
+  let feeCharged = BigInt(0);
+
+  if (transferFeeBasisPoints !== BigInt(0)) {
+    const numerator = transferAmount * ONE_IN_BASIS_POINTS;
+    const denominator = ONE_IN_BASIS_POINTS - transferFeeBasisPoints;
+    const rawPreFeeAmount = divCeilN(numerator, denominator);
+    const fee = rawPreFeeAmount - transferAmount;
+    transferAmount = rawPreFeeAmount;
+    feeCharged = fee > transferFee.maximumFee ? transferFee.maximumFee : fee;
+  }
+
+  return { transferAmount, feeCharged };
 }

--- a/packages/distributor/solana/utils.ts
+++ b/packages/distributor/solana/utils.ts
@@ -5,6 +5,8 @@ import { ConfirmationParams, signAndExecuteTransaction, ThrottleParams } from "@
 
 import { fromTxError } from "./generated/errors";
 
+export const ceilN = (n: bigint, d: bigint): bigint => n / d + (n % d ? BigInt(1) : BigInt(0));
+
 export function getDistributorPda(programId: PublicKey, mint: PublicKey, version: number): PublicKey {
   // Constructing the seed for the PDA
   const seeds = [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",


### PR DESCRIPTION
When creating an Airdrop for mint with Transfer Fee extension we need to account for such fees, so that the Escrow has enough funds to distribute.

Logic loosely based on what we have in Rust Solana library https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/transfer_fee/mod.rs#L90

Example transaction https://explorer.solana.com/tx/51qRMSAy8bXW93mGekBZZjQPv7zjja6Eibfab2j2RVKBSVFnn6Fo8qCap1CNPVWybKwQMfj12KpDyayqqwRRP2sU?cluster=devnet