### PR TITLE
Switch to bignumber.js in v7

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,20 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
 . "$(dirname -- "$0")/_/husky.sh"
+
+TARGET_FOLDER="packages/distributor/solana/generated" 
+
+OS=$(uname)
+
+echo "Replacing 'BN' with 'BigNumber' in $TARGET_FOLDER and its subfolders"
+if [ "$OS" = "Darwin" ]; then
+    SED_NO_BACKUP=( -i '' )
+else
+    SED_NO_BACKUP=( -i )
+fi
+
+find "$TARGET_FOLDER" -type f -name "*.ts" -exec sed "${SED_NO_BACKUP[@]}" -e 's/BN/BigNumber/g' -e 's/bn/bignumber/g' {} +
+
+git add $TARGET_FOLDER
 
 npm run lint

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,6 +41,7 @@
     "@solana/wallet-adapter-base": "0.9.19",
     "@solana/web3.js": "1.70.1",
     "aptos": "1.4.0",
+    "bignumber.js": "^9.1.2",
     "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,7 +30,6 @@
   "gitHead": "a37306eba0e762af096db642fa22f07194014cfd",
   "devDependencies": {
     "@streamflow/eslint-config": "workspace:*",
-    "@types/bn.js": "5.1.1",
     "date-fns": "2.28.0",
     "typescript": "^4.9.5"
   },
@@ -42,7 +41,6 @@
     "@solana/web3.js": "1.70.1",
     "aptos": "1.4.0",
     "bignumber.js": "^9.1.2",
-    "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",
     "p-queue": "^8.0.1"

--- a/packages/common/solana/instructions.ts
+++ b/packages/common/solana/instructions.ts
@@ -26,7 +26,6 @@ export const prepareWrappedAccount = async (
     SystemProgram.transfer({
       fromPubkey: senderAddress,
       toPubkey: tokenAccount,
-      // pow 10 by decimals - probably since getNumberFromBN wasn't used
       lamports: amount.toNumber(),
     }),
     createSyncNativeInstruction(tokenAccount),

--- a/packages/common/solana/instructions.ts
+++ b/packages/common/solana/instructions.ts
@@ -5,12 +5,12 @@ import {
   createSyncNativeInstruction,
 } from "@solana/spl-token";
 import { Connection, PublicKey, SystemProgram, TransactionInstruction } from "@solana/web3.js";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 export const prepareWrappedAccount = async (
   connection: Connection,
   senderAddress: PublicKey,
-  amount: BN,
+  amount: BigNumber,
 ): Promise<TransactionInstruction[]> => {
   const tokenAccount = await getAssociatedTokenAddress(NATIVE_MINT, senderAddress, true);
 
@@ -26,6 +26,7 @@ export const prepareWrappedAccount = async (
     SystemProgram.transfer({
       fromPubkey: senderAddress,
       toPubkey: tokenAccount,
+      // pow 10 by decimals - probably since getNumberFromBN wasn't used
       lamports: amount.toNumber(),
     }),
     createSyncNativeInstruction(tokenAccount),

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -1,32 +1,26 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { ContractError } from "./types.js";
 
 /**
- * Used for conversion of token amounts to their Big Number representation.
- * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BN representation.
+ * Used for token amounts conversion from their Big Number representation to number.
+ * Get value in the highest units from BigNumber representation of the same value in the smallest units.
+ * @param {BigNumber} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BN => {
-  const decimalPart = value - Math.trunc(value);
-  const integerPart = new BN(Math.trunc(value));
-
-  const decimalE = new BN(decimalPart * 1e9);
-
-  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
-  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
-  return resultE.div(new BN(1e9));
+export const getNumberFromBigNumber = (bigNum: BigNumber, decimals: number): number => {
+  return bigNum.div(BigNumber(10).pow(decimals)).toNumber();
 };
 
 /**
- * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BN representation of the same value in the smallest units.
- * @param {BN} value - Big Number representation of value in the smallest units.
+ * Used for conversion of token amounts to their Big Number representation.
+ * Get Big Number representation in the smallest units from the same value in the highest units.
+ * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BN, decimals: number): number =>
-  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
+export const getScaledBigNumber = (value: number | string | BigNumber, decimals: number): BigNumber => {
+  return new BigNumber(value).times(new BigNumber(10).pow(decimals));
+};
 
 /**
  * Used to make on chain calls to the contract and wrap raised errors if any

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -1,32 +1,34 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { ContractError } from "./types.js";
 
 /**
  * Used for conversion of token amounts to their Big Number representation.
  * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BN representation.
+ * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BN => {
+export const getBN = (value: number, decimals: number): BigNumber => {
   const decimalPart = value - Math.trunc(value);
-  const integerPart = new BN(Math.trunc(value));
+  const integerPart = BigNumber(Math.trunc(value));
 
-  const decimalE = new BN(decimalPart * 1e9);
+  const decimalE = BigNumber(decimalPart * 1e9);
 
-  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
-  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
-  return resultE.div(new BN(1e9));
+  const sum = integerPart.times(BigNumber(1e9)).plus(decimalE);
+  const resultE = sum.times(BigNumber(10).pow(BigNumber(decimals)));
+  return resultE.div(BigNumber(1e9));
 };
 
 /**
  * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BN representation of the same value in the smallest units.
- * @param {BN} value - Big Number representation of value in the smallest units.
+ * Get value in the highest units from BigNumber representation of the same value in the smallest units.
+ * @param {BigNumber} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BN, decimals: number): number =>
-  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
+export const getNumberFromBN = (value: BigNumber, decimals: number): number =>
+  value.gt(BigNumber(2 ** 53 - 1))
+    ? value.div(BigNumber(10 ** decimals)).toNumber()
+    : value.toNumber() / 10 ** decimals;
 
 /**
  * Used to make on chain calls to the contract and wrap raised errors if any

--- a/packages/common/utils.ts
+++ b/packages/common/utils.ts
@@ -1,34 +1,32 @@
-import BigNumber from "bignumber.js";
+import BN from "bn.js";
 
 import { ContractError } from "./types.js";
 
 /**
  * Used for conversion of token amounts to their Big Number representation.
  * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
+ * @param {number} value - Number of tokens you want to convert to its BN representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BigNumber => {
+export const getBN = (value: number, decimals: number): BN => {
   const decimalPart = value - Math.trunc(value);
-  const integerPart = BigNumber(Math.trunc(value));
+  const integerPart = new BN(Math.trunc(value));
 
-  const decimalE = BigNumber(decimalPart * 1e9);
+  const decimalE = new BN(decimalPart * 1e9);
 
-  const sum = integerPart.times(BigNumber(1e9)).plus(decimalE);
-  const resultE = sum.times(BigNumber(10).pow(BigNumber(decimals)));
-  return resultE.div(BigNumber(1e9));
+  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
+  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
+  return resultE.div(new BN(1e9));
 };
 
 /**
  * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BigNumber representation of the same value in the smallest units.
- * @param {BigNumber} value - Big Number representation of value in the smallest units.
+ * Get value in the highest units from BN representation of the same value in the smallest units.
+ * @param {BN} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BigNumber, decimals: number): number =>
-  value.gt(BigNumber(2 ** 53 - 1))
-    ? value.div(BigNumber(10 ** decimals)).toNumber()
-    : value.toNumber() / 10 ** decimals;
+export const getNumberFromBN = (value: BN, decimals: number): number =>
+  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
 
 /**
  * Used to make on chain calls to the contract and wrap raised errors if any

--- a/packages/distributor/README.md
+++ b/packages/distributor/README.md
@@ -24,7 +24,6 @@ API Documentation available here: [docs site →](https://streamflow-finance.git
 Most common imports:
 
 ```javascript
-import { BN } from "bn.js";
 import { ICluster } from "@streamflow/common";
 import { SolanaDistributorClient } from "@streamflow/distributor/solana";
 ```
@@ -60,8 +59,8 @@ const res = await client.create(
       54, 218, 49, 68, 131, 214, 250, 113, 37, 143, 167, 73, 17, 54, 233, 26, 141, 93, 28, 186, 137, 211, 251, 205,
       240, 192, 134, 208, 108, 246, 0, 191,
     ], // Merkle root
-    maxNumNodes: new BN("4"), // Number of recipients
-    maxTotalClaim: new BN("4000000000"), // Total amount to distribute
+    maxNumNodes: 4, // Number of recipients
+    maxTotalClaim: "4000000000", // Total amount to distribute
     unlockPeriod: 1, // Unlock period in seconds
     startVestingTs: 0, // Timestamp when Airdrop starts
     endVestingTs: now + 3600 * 24 * 7, // Timestamp when Airdrop ends
@@ -92,8 +91,8 @@ const claimRes = await client.claim(
         43, 104, 75, 183, 12, 38, 37, 153,
       ],
     ], // Merkle Proof used to verify claim
-    amountUnlocked: new BN("0"), // Total amount unlocked for a Recipient
-    amountLocked: new BN("1000000000"), // Total amount locked for a Recipient
+    amountUnlocked: "0", // Total amount unlocked for a Recipient
+    amountLocked: "1000000000", // Total amount locked for a Recipient
   },
   solanaParams,
 );

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -29,7 +29,6 @@
   "gitHead": "a37306eba0e762af096db642fa22f07194014cfd",
   "devDependencies": {
     "@streamflow/eslint-config": "workspace:*",
-    "@types/bn.js": "5.1.1",
     "date-fns": "2.28.0",
     "typescript": "^4.9.5"
   },
@@ -41,7 +40,6 @@
     "@solana/web3.js": "1.70.1",
     "@streamflow/common": "workspace:*",
     "bignumber.js": "^9.1.2",
-    "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",
     "p-queue": "^8.0.1"

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -40,6 +40,7 @@
     "@solana/wallet-adapter-base": "0.9.19",
     "@solana/web3.js": "1.70.1",
     "@streamflow/common": "workspace:*",
+    "bignumber.js": "^9.1.2",
     "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/distributor/solana/client.ts
+++ b/packages/distributor/solana/client.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import PQueue from "p-queue";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -136,14 +136,14 @@ export default class SolanaDistributorClient {
     const senderTokens = await ata(mint, extParams.invoker.publicKey, tokenProgramId);
 
     const args: NewDistributorArgs = {
-      version: new BN(data.version, 10),
+      version: BigNumber(data.version),
       root: data.root,
       maxTotalClaim: data.maxTotalClaim,
       maxNumNodes: data.maxNumNodes,
-      unlockPeriod: new BN(data.unlockPeriod, 10),
-      startVestingTs: new BN(data.startVestingTs, 10),
-      endVestingTs: new BN(data.endVestingTs, 10),
-      clawbackStartTs: new BN(data.clawbackStartTs, 10),
+      unlockPeriod: BigNumber(data.unlockPeriod),
+      startVestingTs: BigNumber(data.startVestingTs),
+      endVestingTs: BigNumber(data.endVestingTs),
+      clawbackStartTs: BigNumber(data.clawbackStartTs),
       claimsClosable: data.claimsClosable,
     };
     const accounts: NewDistributorAccounts = {
@@ -161,10 +161,10 @@ export default class SolanaDistributorClient {
       ixs.push(...(await prepareWrappedAccount(this.connection, extParams.invoker.publicKey, data.maxTotalClaim)));
     }
 
-    const nowTs = new BN(Math.floor(Date.now() / 1000));
-    const endVestingTs = args.endVestingTs.eqn(0) ? nowTs : args.endVestingTs;
-    const startVestingTs = args.startVestingTs.eqn(0) ? nowTs : args.startVestingTs;
-    if (endVestingTs.gt(startVestingTs) && endVestingTs.sub(startVestingTs).lt(args.unlockPeriod)) {
+    const nowTs = BigNumber(Math.floor(Date.now() / 1000));
+    const endVestingTs = args.endVestingTs.isZero() ? nowTs : args.endVestingTs;
+    const startVestingTs = args.startVestingTs.isZero() ? nowTs : args.startVestingTs;
+    if (endVestingTs.gt(startVestingTs) && endVestingTs.minus(startVestingTs).lt(args.unlockPeriod)) {
       throw new Error("The unlock period cannot be longer than the total vesting duration!");
     }
 
@@ -283,8 +283,8 @@ export default class SolanaDistributorClient {
       ixs.push(newClaim(args, accounts, this.programId));
     }
 
-    const nowTs = new BN(Math.floor(Date.now() / 1000));
-    if (claimStatus || (data.amountLocked.gtn(0) && nowTs.sub(distributor.startTs).gte(distributor.unlockPeriod))) {
+    const nowTs = BigNumber(Math.floor(Date.now() / 1000));
+    if (claimStatus || (data.amountLocked.gt(0) && nowTs.minus(distributor.startTs).gte(distributor.unlockPeriod))) {
       ixs.push(claimLocked(accounts, this.programId));
     }
 

--- a/packages/distributor/solana/client.ts
+++ b/packages/distributor/solana/client.ts
@@ -138,8 +138,8 @@ export default class SolanaDistributorClient {
     const args: NewDistributorArgs = {
       version: BigNumber(data.version),
       root: data.root,
-      maxTotalClaim: data.maxTotalClaim,
-      maxNumNodes: data.maxNumNodes,
+      maxTotalClaim: BigNumber(data.maxTotalClaim),
+      maxNumNodes: BigNumber(data.maxNumNodes),
       unlockPeriod: BigNumber(data.unlockPeriod),
       startVestingTs: BigNumber(data.startVestingTs),
       endVestingTs: BigNumber(data.endVestingTs),
@@ -158,7 +158,9 @@ export default class SolanaDistributorClient {
     };
 
     if (extParams.isNative) {
-      ixs.push(...(await prepareWrappedAccount(this.connection, extParams.invoker.publicKey, data.maxTotalClaim)));
+      ixs.push(
+        ...(await prepareWrappedAccount(this.connection, extParams.invoker.publicKey, BigNumber(data.maxTotalClaim))),
+      );
     }
 
     const nowTs = BigNumber(Math.floor(Date.now() / 1000));
@@ -276,15 +278,18 @@ export default class SolanaDistributorClient {
 
     if (!claimStatus) {
       const args: NewClaimArgs = {
-        amountLocked: data.amountLocked,
-        amountUnlocked: data.amountUnlocked,
+        amountLocked: BigNumber(data.amountLocked),
+        amountUnlocked: BigNumber(data.amountUnlocked),
         proof: data.proof,
       };
       ixs.push(newClaim(args, accounts, this.programId));
     }
 
     const nowTs = BigNumber(Math.floor(Date.now() / 1000));
-    if (claimStatus || (data.amountLocked.gt(0) && nowTs.minus(distributor.startTs).gte(distributor.unlockPeriod))) {
+    if (
+      claimStatus ||
+      (BigNumber(data.amountLocked).gt(0) && nowTs.minus(distributor.startTs).gte(distributor.unlockPeriod))
+    ) {
       ixs.push(claimLocked(accounts, this.programId));
     }
 

--- a/packages/distributor/solana/generated/accounts/ClaimStatus.ts
+++ b/packages/distributor/solana/generated/accounts/ClaimStatus.ts
@@ -1,5 +1,5 @@
 import { PublicKey, Connection } from "@solana/web3.js";
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import BigNumber from "bignumber.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 import { PROGRAM_ID } from "../programId";
@@ -8,15 +8,15 @@ export interface ClaimStatusFields {
   /** Authority that claimed the tokens. */
   claimant: PublicKey;
   /** Locked amount */
-  lockedAmount: BN;
+  lockedAmount: BigNumber;
   /** Locked amount withdrawn */
-  lockedAmountWithdrawn: BN;
+  lockedAmountWithdrawn: BigNumber;
   /** Unlocked amount */
-  unlockedAmount: BN;
+  unlockedAmount: BigNumber;
   /** Last claim time */
-  lastClaimTs: BN;
+  lastClaimTs: BigNumber;
   /** Track amount per unlock, can be useful for non-linear vesting */
-  lastAmountPerUnlock: BN;
+  lastAmountPerUnlock: BigNumber;
   /** Whether claim is closed */
   closed: boolean;
   /** Buffer for additional fields */
@@ -52,19 +52,19 @@ export class ClaimStatus {
   readonly claimant: PublicKey;
 
   /** Locked amount */
-  readonly lockedAmount: BN;
+  readonly lockedAmount: BigNumber;
 
   /** Locked amount withdrawn */
-  readonly lockedAmountWithdrawn: BN;
+  readonly lockedAmountWithdrawn: BigNumber;
 
   /** Unlocked amount */
-  readonly unlockedAmount: BN;
+  readonly unlockedAmount: BigNumber;
 
   /** Last claim time */
-  readonly lastClaimTs: BN;
+  readonly lastClaimTs: BigNumber;
 
   /** Track amount per unlock, can be useful for non-linear vesting */
-  readonly lastAmountPerUnlock: BN;
+  readonly lastAmountPerUnlock: BigNumber;
 
   /** Whether claim is closed */
   readonly closed: boolean;
@@ -174,11 +174,11 @@ export class ClaimStatus {
   static fromJSON(obj: ClaimStatusJSON): ClaimStatus {
     return new ClaimStatus({
       claimant: new PublicKey(obj.claimant),
-      lockedAmount: new BN(obj.lockedAmount),
-      lockedAmountWithdrawn: new BN(obj.lockedAmountWithdrawn),
-      unlockedAmount: new BN(obj.unlockedAmount),
-      lastClaimTs: new BN(obj.lastClaimTs),
-      lastAmountPerUnlock: new BN(obj.lastAmountPerUnlock),
+      lockedAmount: BigNumber(obj.lockedAmount),
+      lockedAmountWithdrawn: BigNumber(obj.lockedAmountWithdrawn),
+      unlockedAmount: BigNumber(obj.unlockedAmount),
+      lastClaimTs: BigNumber(obj.lastClaimTs),
+      lastAmountPerUnlock: BigNumber(obj.lastAmountPerUnlock),
       closed: obj.closed,
       buffer1: obj.buffer1,
       buffer2: obj.buffer2,

--- a/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
+++ b/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
@@ -1,5 +1,5 @@
 import { PublicKey, Connection } from "@solana/web3.js";
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import BigNumber from "bignumber.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 import { PROGRAM_ID } from "../programId";
@@ -8,7 +8,7 @@ export interface MerkleDistributorFields {
   /** Bump seed. */
   bump: number;
   /** Version of the airdrop */
-  version: BN;
+  version: BigNumber;
   /** The 256-bit merkle root. */
   root: Array<number>;
   /** [Mint] of the token to be distributed. */
@@ -16,21 +16,21 @@ export interface MerkleDistributorFields {
   /** Token Address of the vault */
   tokenVault: PublicKey;
   /** Maximum number of tokens that can ever be claimed from this [MerkleDistributor]. */
-  maxTotalClaim: BN;
+  maxTotalClaim: BigNumber;
   /** Maximum number of nodes in [MerkleDistributor]. */
-  maxNumNodes: BN;
+  maxNumNodes: BigNumber;
   /** Time step (period) in seconds per which the unlock occurs */
-  unlockPeriod: BN;
+  unlockPeriod: BigNumber;
   /** Total amount of tokens that have been claimed. */
-  totalAmountClaimed: BN;
+  totalAmountClaimed: BigNumber;
   /** Number of nodes that have been claimed. */
-  numNodesClaimed: BN;
+  numNodesClaimed: BigNumber;
   /** Lockup time start (Unix Timestamp) */
-  startTs: BN;
+  startTs: BigNumber;
   /** Lockup time end (Unix Timestamp) */
-  endTs: BN;
+  endTs: BigNumber;
   /** Clawback start (Unix Timestamp) */
-  clawbackStartTs: BN;
+  clawbackStartTs: BigNumber;
   /** Clawback receiver */
   clawbackReceiver: PublicKey;
   /** Admin wallet */
@@ -96,7 +96,7 @@ export class MerkleDistributor {
   readonly bump: number;
 
   /** Version of the airdrop */
-  readonly version: BN;
+  readonly version: BigNumber;
 
   /** The 256-bit merkle root. */
   readonly root: Array<number>;
@@ -108,28 +108,28 @@ export class MerkleDistributor {
   readonly tokenVault: PublicKey;
 
   /** Maximum number of tokens that can ever be claimed from this [MerkleDistributor]. */
-  readonly maxTotalClaim: BN;
+  readonly maxTotalClaim: BigNumber;
 
   /** Maximum number of nodes in [MerkleDistributor]. */
-  readonly maxNumNodes: BN;
+  readonly maxNumNodes: BigNumber;
 
   /** Time step (period) in seconds per which the unlock occurs */
-  readonly unlockPeriod: BN;
+  readonly unlockPeriod: BigNumber;
 
   /** Total amount of tokens that have been claimed. */
-  readonly totalAmountClaimed: BN;
+  readonly totalAmountClaimed: BigNumber;
 
   /** Number of nodes that have been claimed. */
-  readonly numNodesClaimed: BN;
+  readonly numNodesClaimed: BigNumber;
 
   /** Lockup time start (Unix Timestamp) */
-  readonly startTs: BN;
+  readonly startTs: BigNumber;
 
   /** Lockup time end (Unix Timestamp) */
-  readonly endTs: BN;
+  readonly endTs: BigNumber;
 
   /** Clawback start (Unix Timestamp) */
-  readonly clawbackStartTs: BN;
+  readonly clawbackStartTs: BigNumber;
 
   /** Clawback receiver */
   readonly clawbackReceiver: PublicKey;
@@ -295,18 +295,18 @@ export class MerkleDistributor {
   static fromJSON(obj: MerkleDistributorJSON): MerkleDistributor {
     return new MerkleDistributor({
       bump: obj.bump,
-      version: new BN(obj.version),
+      version: BigNumber(obj.version),
       root: obj.root,
       mint: new PublicKey(obj.mint),
       tokenVault: new PublicKey(obj.tokenVault),
-      maxTotalClaim: new BN(obj.maxTotalClaim),
-      maxNumNodes: new BN(obj.maxNumNodes),
-      unlockPeriod: new BN(obj.unlockPeriod),
-      totalAmountClaimed: new BN(obj.totalAmountClaimed),
-      numNodesClaimed: new BN(obj.numNodesClaimed),
-      startTs: new BN(obj.startTs),
-      endTs: new BN(obj.endTs),
-      clawbackStartTs: new BN(obj.clawbackStartTs),
+      maxTotalClaim: BigNumber(obj.maxTotalClaim),
+      maxNumNodes: BigNumber(obj.maxNumNodes),
+      unlockPeriod: BigNumber(obj.unlockPeriod),
+      totalAmountClaimed: BigNumber(obj.totalAmountClaimed),
+      numNodesClaimed: BigNumber(obj.numNodesClaimed),
+      startTs: BigNumber(obj.startTs),
+      endTs: BigNumber(obj.endTs),
+      clawbackStartTs: BigNumber(obj.clawbackStartTs),
       clawbackReceiver: new PublicKey(obj.clawbackReceiver),
       admin: new PublicKey(obj.admin),
       clawedBack: obj.clawedBack,

--- a/packages/distributor/solana/generated/instructions/claimLocked.ts
+++ b/packages/distributor/solana/generated/instructions/claimLocked.ts
@@ -1,6 +1,4 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 import { PROGRAM_ID } from "../programId";
 

--- a/packages/distributor/solana/generated/instructions/clawback.ts
+++ b/packages/distributor/solana/generated/instructions/clawback.ts
@@ -1,5 +1,4 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from "buffer";
 

--- a/packages/distributor/solana/generated/instructions/closeClaim.ts
+++ b/packages/distributor/solana/generated/instructions/closeClaim.ts
@@ -1,5 +1,4 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from "buffer";
 

--- a/packages/distributor/solana/generated/instructions/newClaim.ts
+++ b/packages/distributor/solana/generated/instructions/newClaim.ts
@@ -1,12 +1,12 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import BigNumber from "bignumber.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 import { PROGRAM_ID } from "../programId";
 
 export interface NewClaimArgs {
-  amountUnlocked: BN;
-  amountLocked: BN;
+  amountUnlocked: BigNumber;
+  amountLocked: BigNumber;
   proof: Array<Array<number>>;
 }
 

--- a/packages/distributor/solana/generated/instructions/newDistributor.ts
+++ b/packages/distributor/solana/generated/instructions/newDistributor.ts
@@ -1,19 +1,19 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import BigNumber from "bignumber.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from "buffer";
 
 import { PROGRAM_ID } from "../programId";
 
 export interface NewDistributorArgs {
-  version: BN;
+  version: BigNumber;
   root: Array<number>;
-  maxTotalClaim: BN;
-  maxNumNodes: BN;
-  unlockPeriod: BN;
-  startVestingTs: BN;
-  endVestingTs: BN;
-  clawbackStartTs: BN;
+  maxTotalClaim: BigNumber;
+  maxNumNodes: BigNumber;
+  unlockPeriod: BigNumber;
+  startVestingTs: BigNumber;
+  endVestingTs: BigNumber;
+  clawbackStartTs: BigNumber;
   claimsClosable: boolean;
 }
 

--- a/packages/distributor/solana/generated/instructions/setAdmin.ts
+++ b/packages/distributor/solana/generated/instructions/setAdmin.ts
@@ -1,5 +1,4 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from "buffer";
 

--- a/packages/distributor/solana/generated/instructions/setClawbackReceiver.ts
+++ b/packages/distributor/solana/generated/instructions/setClawbackReceiver.ts
@@ -1,5 +1,4 @@
 import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import BN from "bn.js"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import * as borsh from "@coral-xyz/borsh"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from "buffer";
 

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -1,4 +1,3 @@
-import BigNumber from "bignumber.js";
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
 import { Keypair } from "@solana/web3.js";
 import { ITransactionResult } from "@streamflow/common";
@@ -17,8 +16,8 @@ export interface ICreateDistributorData {
   version: number;
 
   root: Array<number>;
-  maxTotalClaim: BigNumber;
-  maxNumNodes: BigNumber;
+  maxTotalClaim: number | string;
+  maxNumNodes: number | string;
   unlockPeriod: number;
   startVestingTs: number;
   endVestingTs: number;
@@ -29,8 +28,8 @@ export interface ICreateDistributorData {
 export interface IClaimData {
   id: string;
 
-  amountUnlocked: BigNumber;
-  amountLocked: BigNumber;
+  amountUnlocked: number | string;
+  amountLocked: number | string;
   proof: Array<Array<number>>;
 }
 

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
 import { Keypair } from "@solana/web3.js";
 import { ITransactionResult } from "@streamflow/common";
@@ -17,8 +17,8 @@ export interface ICreateDistributorData {
   version: number;
 
   root: Array<number>;
-  maxTotalClaim: BN;
-  maxNumNodes: BN;
+  maxTotalClaim: BigNumber;
+  maxNumNodes: BigNumber;
   unlockPeriod: number;
   startVestingTs: number;
   endVestingTs: number;
@@ -29,8 +29,8 @@ export interface ICreateDistributorData {
 export interface IClaimData {
   id: string;
 
-  amountUnlocked: BN;
-  amountLocked: BN;
+  amountUnlocked: BigNumber;
+  amountLocked: BigNumber;
   proof: Array<Array<number>>;
 }
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -423,7 +423,7 @@ const stream = await client.getOne({
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA",
 });
 
-const unlocked = stream.unlocked(tsInSeconds); // bn amount unlocked at the tsInSeconds
+const unlocked = stream.unlocked(tsInSeconds); // bignumber amount unlocked at the tsInSeconds
 console.log(getNumberFromBigNumber(unlocked, 9));
 ```
 
@@ -435,7 +435,7 @@ console.log(getNumberFromBigNumber(unlocked, 9));
 const stream = await client.getOne({
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA",
 });
-const withdrawn = stream.withdrawnAmount; // bn amount withdrawn already
+const withdrawn = stream.withdrawnAmount; // big number amount withdrawn already
 console.log(getNumberFromBigNumber(wihtdrawn, 9));
 const remaining = stream.remaining(9); // amount of remaining funds
 console.log(remaining);

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -22,8 +22,7 @@ API Documentation available here: [docs site →](https://streamflow-finance.git
 Most common imports:
 
 ```javascript
-import { BN } from "bn.js";
-import { Types, GenericStreamClient, getBN, getNumberFromBN } from "@streamflow/stream";
+import { Types, GenericStreamClient, getScaledBigNumber, getNumberFromBigNumber } from "@streamflow/stream";
 ```
 
 _Check the SDK for other types and utility functions._
@@ -143,11 +142,11 @@ const createStreamParams: Types.ICreateStreamData = {
   recipient: "4ih00075bKjVg000000tLdk4w42NyG3Mv0000dc0M00", // Recipient address.
   tokenId: "DNw99999M7e24g99999999WJirKeZ5fQc6KY999999gK", // Token mint address.
   start: 1643363040, // Timestamp (in seconds) when the stream/token vesting starts.
-  amount: getBN(100, 9), // depositing 100 tokens with 9 decimals mint.
+  amount: getScaledBigNumber(100, 9), // depositing 100 tokens with 9 decimals mint.
   period: 1, // Time step (period) in seconds per which the unlocking occurs.
   cliff: 1643363160, // Vesting contract "cliff" timestamp in seconds.
-  cliffAmount: new BN(10), // Amount unlocked at the "cliff" timestamp.
-  amountPerPeriod: getBN(5, 9), // Release rate: how many tokens are unlocked per each period.
+  cliffAmount: 10, // Amount unlocked at the "cliff" timestamp.
+  amountPerPeriod: getScaledBigNumber(5, 9), // Release rate: how many tokens are unlocked per each period.
   name: "Transfer to Jane Doe.", // The stream name or subject.
   canTopup: false, // setting to FALSE will effectively create a vesting contract.
   canUpdateRate: false, // settings to TRUE allows sender to update amountPerPeriod
@@ -188,10 +187,10 @@ try {
 const recipients = [
   {
     recipient: "4ih00075bKjVg000000tLdk4w42NyG3Mv0000dc0M00", // Solana recipient address.
-    amount: getBN(100, 9), // depositing 100 tokens with 9 decimals mint.
+    amount: getScaledBgNumber(100, 9), // depositing 100 tokens with 9 decimals mint.
     name: "January Payroll", // The stream name/subject.
-    cliffAmount: getBN(10, 9), // amount released on cliff for this recipient
-    amountPerPeriod: getBN(1, 9), //amount released every specified period epoch
+    cliffAmount: getScaledBgNumber(10, 9), // amount released on cliff for this recipient
+    amountPerPeriod: getScaledBgNumber(1, 9), //amount released every specified period epoch
   },
 ];
 const createStreamParams: Types.ICreateMultipleStreamData = {
@@ -253,7 +252,7 @@ interface ICreateResult {
 ```javascript
 const withdrawStreamParams: Types.IWithdrawData = {
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA", // Identifier of a stream to be withdrawn from.
-  amount: getBN(100, 9), // Requested amount to withdraw. If stream is completed, the whole amount will be withdrawn.
+  amount: getScaledBgNumber(100, 9), // Requested amount to withdraw. If stream is completed, the whole amount will be withdrawn.
 };
 
 const solanaParams = {
@@ -284,7 +283,7 @@ try {
 ```javascript
 const topupStreamParams: Types.ITopUpData = {
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA", // Identifier of a stream to be topped up.
-  amount: getBN(100, 9), // Specified amount to topup (increases deposited amount).
+  amount: getScaledBgNumber(100, 9), // Specified amount to topup (increases deposited amount).
 };
 
 const solanaParams = {
@@ -379,7 +378,7 @@ const updateStreamParams: Types.IUpdateData = {
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA", // Identifier of a stream to update.
   enableAutomaticWithdrawal: true,  // [optional], allows to enable AW if it wasn't, disable is not possible
   withdrawFrequency: 60,  // [optional], allows to update withdrawal frequency, may result in additional AW fees
-  amountPerPeriod: getBN(10, 9),  // [optional], allows to update release amount effective on next unlock
+  amountPerPeriod: getScaledBgNumber(10, 9),  // [optional], allows to update release amount effective on next unlock
 }
 
 const solanaParams = {
@@ -425,7 +424,7 @@ const stream = await client.getOne({
 });
 
 const unlocked = stream.unlocked(tsInSeconds); // bn amount unlocked at the tsInSeconds
-console.log(getNumberFromBN(unlocked, 9));
+console.log(getNumberFromBigNumber(unlocked, 9));
 ```
 
 - Note: unlocked amount is determined based on configuration set on creation, no dynamic data is involved.
@@ -437,7 +436,7 @@ const stream = await client.getOne({
   id: "AAAAyotqTZZMAAAAmsD1JAgksT8NVAAAASfrGB5RAAAA",
 });
 const withdrawn = stream.withdrawnAmount; // bn amount withdrawn already
-console.log(getNumberFromBN(wihtdrawn, 9));
+console.log(getNumberFromBigNumber(wihtdrawn, 9));
 const remaining = stream.remaining(9); // amount of remaining funds
 console.log(remaining);
 ```
@@ -492,10 +491,10 @@ Streamflow protocol program IDs
 | Testnet | 0xf1916c119a6c917d4b36f96ffc0443930745789f3126a716e05a62223c48993a |
 | Mainnet | 0xa283fd6b45f1103176e7ae27e870c89df7c8783b15345e2b13faa81ec25c4fa6 |
 
-**All BN amounts are denominated in their smallest units.**
+**All BigNumber amounts are denominated in their smallest units.**
 
 E.g, if the amount is 1 SOL than this amount in lamports is `1000 \* 10^9 = 1_000_000_000.`
 
-And `new BN(1_000_000_000)` is used.
+And `BigNumber(1_000_000_000)` is used.
 
-Use `getBN` and `getNumberFromBN` utility functions for conversions between `BN` and `Number` types.
+Use `getscaledBigNumber` and `getNumberFromBigNumber` utility functions for conversions between `BigNumber` and `Number` types.

--- a/packages/stream/__tests__/aptos/streamClient.spec.ts
+++ b/packages/stream/__tests__/aptos/streamClient.spec.ts
@@ -1,4 +1,4 @@
-import { BN } from "bn.js";
+import { BigNumber } from "bignumber.js";
 import { describe, expect, test, beforeEach, vi } from "vitest";
 
 import AptosStreamClient from "../../aptos/StreamClient.js";
@@ -40,10 +40,10 @@ describe("AptosStreamClient", () => {
       };
       const mockRecipient = {
         recipient: "0xtest",
-        amount: new BN(1000),
+        amount: BigNumber(1000),
         name: "test name",
-        cliffAmount: new BN(1),
-        amountPerPeriod: new BN(1),
+        cliffAmount: BigNumber(1),
+        amountPerPeriod: BigNumber(1),
       };
       const mockData = {
         period: 100,

--- a/packages/stream/__tests__/aptos/streamClient.spec.ts
+++ b/packages/stream/__tests__/aptos/streamClient.spec.ts
@@ -42,7 +42,7 @@ describe("AptosStreamClient", () => {
         recipient: "0xtest",
         amount: BigNumber(1000),
         name: "test name",
-        cliffAmount: BigNumber(1),
+        cliffAmount: 1,
         amountPerPeriod: BigNumber(1),
       };
       const mockData = {

--- a/packages/stream/aptos/types.ts
+++ b/packages/stream/aptos/types.ts
@@ -3,9 +3,10 @@ import { WalletContextState } from "@manahippo/aptos-wallet-adapter";
 import BigNumber from "bignumber.js";
 import { Buffer } from "buffer";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
-import { Stream, StreamType } from "../common/types";
-import { normalizeAptosAddress } from "./utils";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
+import { Stream, StreamType } from "../common/types.js";
+import { normalizeAptosAddress } from "./utils.js";
+import { getNumberFromBigNumber } from "../common/utils.js";
 
 export interface ICreateStreamAptosExt {
   senderWallet: WalletContextState | AptosAccount;
@@ -211,9 +212,6 @@ export class Contract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return this.depositedAmount
-      .minus(this.withdrawnAmount)
-      .div(10 ** decimals)
-      .toNumber();
+    return getNumberFromBigNumber(this.depositedAmount.minus(this.withdrawnAmount), decimals);
   }
 }

--- a/packages/stream/aptos/types.ts
+++ b/packages/stream/aptos/types.ts
@@ -1,12 +1,11 @@
 import { AptosAccount } from "aptos";
 import { WalletContextState } from "@manahippo/aptos-wallet-adapter";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { Buffer } from "buffer";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
-import { Stream, StreamType } from "../common/types.js";
-import { getNumberFromBN } from "../common/utils.js";
-import { normalizeAptosAddress } from "./utils.js";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
+import { Stream, StreamType } from "../common/types";
+import { normalizeAptosAddress } from "./utils";
 
 export interface ICreateStreamAptosExt {
   senderWallet: WalletContextState | AptosAccount;
@@ -77,7 +76,7 @@ export class Contract implements Stream {
 
   createdAt: number;
 
-  withdrawnAmount: BN;
+  withdrawnAmount: BigNumber;
 
   canceledAt: number;
 
@@ -101,15 +100,15 @@ export class Contract implements Stream {
 
   streamflowTreasuryTokens: string;
 
-  streamflowFeeTotal: BN;
+  streamflowFeeTotal: BigNumber;
 
-  streamflowFeeWithdrawn: BN;
+  streamflowFeeWithdrawn: BigNumber;
 
   streamflowFeePercent: number;
 
-  partnerFeeTotal: BN;
+  partnerFeeTotal: BigNumber;
 
-  partnerFeeWithdrawn: BN;
+  partnerFeeWithdrawn: BigNumber;
 
   partnerFeePercent: number;
 
@@ -119,15 +118,15 @@ export class Contract implements Stream {
 
   start: number;
 
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
 
   period: number;
 
-  amountPerPeriod: BN;
+  amountPerPeriod: BigNumber;
 
   cliff: number;
 
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
 
   cancelableBySender: boolean;
 
@@ -149,11 +148,11 @@ export class Contract implements Stream {
 
   currentPauseStart: number;
 
-  pauseCumulative: BN;
+  pauseCumulative: BigNumber;
 
   lastRateChangeTime: number;
 
-  fundsUnlockedAtLastRateChange: BN;
+  fundsUnlockedAtLastRateChange: BigNumber;
 
   type: StreamType;
 
@@ -161,7 +160,7 @@ export class Contract implements Stream {
     this.magic = 0;
     this.version = 0;
     this.createdAt = parseInt(stream.created);
-    this.withdrawnAmount = new BN(stream.withdrawn);
+    this.withdrawnAmount = BigNumber(stream.withdrawn);
     this.canceledAt = parseInt(stream.canceled_at);
     this.end = parseInt(stream.end);
     this.lastWithdrawnAt = parseInt(stream.last_withdrawn_at);
@@ -173,20 +172,20 @@ export class Contract implements Stream {
     this.escrowTokens = "";
     this.streamflowTreasury = "";
     this.streamflowTreasuryTokens = "";
-    this.streamflowFeeTotal = new BN(0);
-    this.streamflowFeeWithdrawn = new BN(0);
+    this.streamflowFeeTotal = BigNumber(0);
+    this.streamflowFeeWithdrawn = BigNumber(0);
     this.streamflowFeePercent = parseInt(stream.fees.streamflow_fee_percentage) / 10000;
-    this.partnerFeeTotal = new BN(0);
-    this.partnerFeeWithdrawn = new BN(0);
+    this.partnerFeeTotal = BigNumber(0);
+    this.partnerFeeWithdrawn = BigNumber(0);
     this.partnerFeePercent = 0;
     this.partner = "";
     this.partnerTokens = "";
     this.start = parseInt(stream.start);
-    this.depositedAmount = new BN(stream.amount);
+    this.depositedAmount = BigNumber(stream.amount);
     this.period = parseInt(stream.period);
-    this.amountPerPeriod = new BN(stream.amount_per_period);
+    this.amountPerPeriod = BigNumber(stream.amount_per_period);
     this.cliff = parseInt(stream.start);
-    this.cliffAmount = new BN(stream.cliff_amount);
+    this.cliffAmount = BigNumber(stream.cliff_amount);
     this.cancelableBySender = stream.meta.cancelable_by_sender;
     this.cancelableByRecipient = stream.meta.cancelable_by_recipient;
     this.automaticWithdrawal = stream.meta.automatic_withdrawal;
@@ -198,20 +197,20 @@ export class Contract implements Stream {
     this.withdrawalFrequency = parseInt(stream.meta.withdrawal_frequency);
     this.closed = stream.closed;
     this.currentPauseStart = parseInt(stream.current_pause_start);
-    this.pauseCumulative = new BN(stream.pause_cumulative);
+    this.pauseCumulative = BigNumber(stream.pause_cumulative);
     this.lastRateChangeTime = parseInt(stream.last_rate_change_time);
-    this.fundsUnlockedAtLastRateChange = new BN(stream.funds_unlocked_at_last_rate_change);
+    this.fundsUnlockedAtLastRateChange = BigNumber(stream.funds_unlocked_at_last_rate_change);
     this.type = buildStreamType(this);
   }
 
-  unlocked(currentTimestamp: number): BN {
+  unlocked(currentTimestamp: number): BigNumber {
     return calculateUnlockedAmount({
       ...this,
       currentTimestamp,
     });
   }
 
-  remaining(decimals: number): number {
-    return getNumberFromBN(this.depositedAmount.sub(this.withdrawnAmount), decimals);
+  remaining(): number {
+    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
   }
 }

--- a/packages/stream/aptos/types.ts
+++ b/packages/stream/aptos/types.ts
@@ -210,7 +210,10 @@ export class Contract implements Stream {
     });
   }
 
-  remaining(): number {
-    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
+  remaining(decimals: number): number {
+    return this.depositedAmount
+      .minus(this.withdrawnAmount)
+      .div(10 ** decimals)
+      .toNumber();
   }
 }

--- a/packages/stream/common/constants.ts
+++ b/packages/stream/common/constants.ts
@@ -1,4 +1,5 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 export const BASE_FEE = 1009900; // Buffer to include usual fees when calculating stream amount
-export const WITHDRAW_AVAILABLE_AMOUNT = new BN("18446744073709551615"); // Magical number to withdraw all available amount from a Contract
+// this magical number needs updating probably
+export const WITHDRAW_AVAILABLE_AMOUNT = BigNumber("18446744073709551615"); // Magical number to withdraw all available amount from a Contract

--- a/packages/stream/common/constants.ts
+++ b/packages/stream/common/constants.ts
@@ -1,5 +1,4 @@
 import BigNumber from "bignumber.js";
 
 export const BASE_FEE = 1009900; // Buffer to include usual fees when calculating stream amount
-// this magical number needs updating probably
 export const WITHDRAW_AVAILABLE_AMOUNT = BigNumber("18446744073709551615"); // Magical number to withdraw all available amount from a Contract

--- a/packages/stream/common/contractUtils.ts
+++ b/packages/stream/common/contractUtils.ts
@@ -1,17 +1,17 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { StreamType } from "./types.js";
 
 interface ICalculateUnlockedAmount {
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
   cliff: number;
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
   end: number;
   currentTimestamp: number;
   lastRateChangeTime: number;
   period: number;
-  amountPerPeriod: BN;
-  fundsUnlockedAtLastRateChange: BN;
+  amountPerPeriod: BigNumber;
+  fundsUnlockedAtLastRateChange: BigNumber;
 }
 
 export const calculateUnlockedAmount = ({
@@ -24,31 +24,38 @@ export const calculateUnlockedAmount = ({
   period,
   amountPerPeriod,
   fundsUnlockedAtLastRateChange,
-}: ICalculateUnlockedAmount): BN => {
+}: ICalculateUnlockedAmount): BigNumber => {
   const deposited = depositedAmount;
 
-  if (currentTimestamp < cliff) return new BN(0);
+  if (currentTimestamp < cliff) return BigNumber(0);
   if (currentTimestamp > end) return deposited;
 
   const savedUnlockedFunds = lastRateChangeTime === 0 ? cliffAmount : fundsUnlockedAtLastRateChange;
   const savedUnlockedFundsTime = lastRateChangeTime === 0 ? cliff : lastRateChangeTime;
 
-  const streamed = new BN(Math.floor((currentTimestamp - savedUnlockedFundsTime) / period))
-    .mul(amountPerPeriod)
-    .add(savedUnlockedFunds);
+  const streamed = BigNumber(Math.floor((currentTimestamp - savedUnlockedFundsTime) / period))
+    .times(amountPerPeriod)
+    .plus(savedUnlockedFunds);
 
   return streamed.lt(deposited) ? streamed : deposited;
 };
 
-export const isCliffCloseToDepositedAmount = (streamData: { depositedAmount: BN; cliffAmount: BN }): boolean => {
-  return streamData.cliffAmount.gte(streamData.depositedAmount.sub(new BN("1")));
+export const isCliffCloseToDepositedAmount = (streamData: {
+  depositedAmount: BigNumber;
+  cliffAmount: BigNumber;
+}): boolean => {
+  return streamData.cliffAmount.gte(streamData.depositedAmount.minus(BigNumber("1")));
 };
 
 export const isPayment = (streamData: { canTopup: boolean }): boolean => {
   return streamData.canTopup;
 };
 
-export const isVesting = (streamData: { canTopup: boolean; depositedAmount: BN; cliffAmount: BN }): boolean => {
+export const isVesting = (streamData: {
+  canTopup: boolean;
+  depositedAmount: BigNumber;
+  cliffAmount: BigNumber;
+}): boolean => {
   return !streamData.canTopup && !isCliffCloseToDepositedAmount(streamData);
 };
 
@@ -59,8 +66,8 @@ export const isTokenLock = (streamData: {
   cancelableByRecipient: boolean;
   transferableBySender: boolean;
   transferableByRecipient: boolean;
-  depositedAmount: BN;
-  cliffAmount: BN;
+  depositedAmount: BigNumber;
+  cliffAmount: BigNumber;
 }): boolean => {
   return (
     !streamData.canTopup &&
@@ -80,8 +87,8 @@ export const buildStreamType = (streamData: {
   cancelableByRecipient: boolean;
   transferableBySender: boolean;
   transferableByRecipient: boolean;
-  depositedAmount: BN;
-  cliffAmount: BN;
+  depositedAmount: BigNumber;
+  cliffAmount: BigNumber;
 }): StreamType => {
   if (isVesting(streamData)) {
     return StreamType.Vesting;

--- a/packages/stream/common/contractUtils.ts
+++ b/packages/stream/common/contractUtils.ts
@@ -44,7 +44,7 @@ export const isCliffCloseToDepositedAmount = (streamData: {
   depositedAmount: BigNumber;
   cliffAmount: BigNumber;
 }): boolean => {
-  return streamData.cliffAmount.gte(streamData.depositedAmount.minus(BigNumber("1")));
+  return streamData.cliffAmount.gte(streamData.depositedAmount.minus(BigNumber(1)));
 };
 
 export const isPayment = (streamData: { canTopup: boolean }): boolean => {

--- a/packages/stream/common/types.ts
+++ b/packages/stream/common/types.ts
@@ -9,7 +9,7 @@ export interface IRecipient {
   recipient: string;
   amount: BigNumber;
   name: string;
-  cliffAmount: BigNumber;
+  cliffAmount: string | number;
   amountPerPeriod: BigNumber;
 }
 

--- a/packages/stream/common/types.ts
+++ b/packages/stream/common/types.ts
@@ -1,16 +1,16 @@
 import { TransactionInstruction } from "@solana/web3.js";
 import { Types } from "aptos";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 export { IChain, ICluster, ContractError } from "@streamflow/common";
 
 // Stream Client Types
 export interface IRecipient {
   recipient: string;
-  amount: BN;
+  amount: BigNumber;
   name: string;
-  cliffAmount: BN;
-  amountPerPeriod: BN;
+  cliffAmount: BigNumber;
+  amountPerPeriod: BigNumber;
 }
 
 export interface IStreamConfig {
@@ -41,13 +41,13 @@ export interface IInteractData {
 }
 
 export interface IWithdrawData extends IInteractData {
-  amount?: BN;
+  amount?: BigNumber;
 }
 
 export interface IUpdateData extends IInteractData {
   enableAutomaticWithdrawal?: boolean;
-  withdrawFrequency?: BN;
-  amountPerPeriod?: BN;
+  withdrawFrequency?: BigNumber;
+  amountPerPeriod?: BigNumber;
 }
 
 export type ICancelData = IInteractData;
@@ -57,7 +57,7 @@ export interface ITransferData extends IInteractData {
 }
 
 export interface ITopUpData extends IInteractData {
-  amount: BN;
+  amount: BigNumber;
 }
 
 export type IGetOneData = IInteractData;
@@ -211,7 +211,7 @@ export interface Stream {
   magic: number;
   version: number;
   createdAt: number;
-  withdrawnAmount: BN;
+  withdrawnAmount: BigNumber;
   canceledAt: number;
   end: number;
   lastWithdrawnAt: number;
@@ -223,20 +223,20 @@ export interface Stream {
   escrowTokens: string;
   streamflowTreasury: string;
   streamflowTreasuryTokens: string;
-  streamflowFeeTotal: BN;
-  streamflowFeeWithdrawn: BN;
+  streamflowFeeTotal: BigNumber;
+  streamflowFeeWithdrawn: BigNumber;
   streamflowFeePercent: number;
-  partnerFeeTotal: BN;
-  partnerFeeWithdrawn: BN;
+  partnerFeeTotal: BigNumber;
+  partnerFeeWithdrawn: BigNumber;
   partnerFeePercent: number;
   partner: string;
   partnerTokens: string;
   start: number;
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
   period: number;
-  amountPerPeriod: BN;
+  amountPerPeriod: BigNumber;
   cliff: number;
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
   cancelableBySender: boolean;
   cancelableByRecipient: boolean;
   automaticWithdrawal: boolean;
@@ -247,13 +247,13 @@ export interface Stream {
   withdrawalFrequency: number;
   closed: boolean;
   currentPauseStart: number;
-  pauseCumulative: BN;
+  pauseCumulative: BigNumber;
   lastRateChangeTime: number;
-  fundsUnlockedAtLastRateChange: BN;
+  fundsUnlockedAtLastRateChange: BigNumber;
 
   type: StreamType;
 
-  unlocked(currentTimestamp: number): BN;
+  unlocked(currentTimestamp: number): BigNumber;
 
   remaining(decimals: number): number;
 }

--- a/packages/stream/common/utils.ts
+++ b/packages/stream/common/utils.ts
@@ -1,49 +1,51 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { ContractError } from "./types.js";
 
 const FEE_PRECISION = 4;
 const FEE_NORMALIZER = 10 ** FEE_PRECISION;
-const FEE_MULTIPLIER = new BN(10 ** 6);
+const FEE_MULTIPLIER = BigNumber(10 ** 6);
 
 /**
  * Used for conversion of token amounts to their Big Number representation.
  * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BN representation.
+ * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BN => {
+export const getBN = (value: number, decimals: number): BigNumber => {
   const decimalPart = value - Math.trunc(value);
-  const integerPart = new BN(Math.trunc(value));
+  const integerPart = BigNumber(Math.trunc(value));
 
-  const decimalE = new BN(decimalPart * 1e9);
+  const decimalE = BigNumber(decimalPart * 1e9);
 
-  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
-  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
-  return resultE.div(new BN(1e9));
+  const sum = integerPart.times(BigNumber(1e9)).plus(decimalE);
+  const resultE = sum.times(BigNumber(10).pow(BigNumber(decimals)));
+  return resultE.div(BigNumber(1e9));
 };
 
 /**
  * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BN representation of the same value in the smallest units.
- * @param {BN} value - Big Number representation of value in the smallest units.
+ * Get value in the highest units from BigNumber representation of the same value in the smallest units.
+ * @param {BigNumber} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BN, decimals: number): number =>
-  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
+export const getNumberFromBN = (value: BigNumber, decimals: number): number =>
+  value.gt(BigNumber(2 ** 53 - 1))
+    ? value.div(BigNumber(10 ** decimals)).toNumber()
+    : value.toNumber() / 10 ** decimals;
 
 /**
  * Calculate total amount of a Contract including all fees.
- * - first we convert fee floating to a BN with up to 4 decimals precision
+ * - first we convert fee floating to a BigNumber with up to 4 decimals precision
  * - then we reverse the fee with `FEE_MULTIPLIER` to safely multiply it by depositedAmount
  *   to receive a total number and not percentage of depositedAmount
  * @param depositedAmount deposited raw tokens
  * @param totalFee sum of all fees in percentage as floating number, e.g. 0.99% should be supplied as 0.99
  * @returns total tokens amount that Contract will retrieve from the Sender
  */
-export const calculateTotalAmountToDeposit = (depositedAmount: BN, totalFee: number): BN => {
-  const totalFeeNormalized = new BN(totalFee * FEE_NORMALIZER);
-  return depositedAmount.mul(totalFeeNormalized.add(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
+export const calculateTotalAmountToDeposit = (depositedAmount: BigNumber, totalFee: number): BigNumber => {
+  const totalFeeNormalized = BigNumber(totalFee * FEE_NORMALIZER);
+  return depositedAmount.times(totalFeeNormalized.plus(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
 };
 
 /**

--- a/packages/stream/common/utils.ts
+++ b/packages/stream/common/utils.ts
@@ -1,51 +1,49 @@
-import BigNumber from "bignumber.js";
+import BN from "bn.js";
 
 import { ContractError } from "./types.js";
 
 const FEE_PRECISION = 4;
 const FEE_NORMALIZER = 10 ** FEE_PRECISION;
-const FEE_MULTIPLIER = BigNumber(10 ** 6);
+const FEE_MULTIPLIER = new BN(10 ** 6);
 
 /**
  * Used for conversion of token amounts to their Big Number representation.
  * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
+ * @param {number} value - Number of tokens you want to convert to its BN representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BigNumber => {
+export const getBN = (value: number, decimals: number): BN => {
   const decimalPart = value - Math.trunc(value);
-  const integerPart = BigNumber(Math.trunc(value));
+  const integerPart = new BN(Math.trunc(value));
 
-  const decimalE = BigNumber(decimalPart * 1e9);
+  const decimalE = new BN(decimalPart * 1e9);
 
-  const sum = integerPart.times(BigNumber(1e9)).plus(decimalE);
-  const resultE = sum.times(BigNumber(10).pow(BigNumber(decimals)));
-  return resultE.div(BigNumber(1e9));
+  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
+  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
+  return resultE.div(new BN(1e9));
 };
 
 /**
  * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BigNumber representation of the same value in the smallest units.
- * @param {BigNumber} value - Big Number representation of value in the smallest units.
+ * Get value in the highest units from BN representation of the same value in the smallest units.
+ * @param {BN} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BigNumber, decimals: number): number =>
-  value.gt(BigNumber(2 ** 53 - 1))
-    ? value.div(BigNumber(10 ** decimals)).toNumber()
-    : value.toNumber() / 10 ** decimals;
+export const getNumberFromBN = (value: BN, decimals: number): number =>
+  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
 
 /**
  * Calculate total amount of a Contract including all fees.
- * - first we convert fee floating to a BigNumber with up to 4 decimals precision
+ * - first we convert fee floating to a BN with up to 4 decimals precision
  * - then we reverse the fee with `FEE_MULTIPLIER` to safely multiply it by depositedAmount
  *   to receive a total number and not percentage of depositedAmount
  * @param depositedAmount deposited raw tokens
  * @param totalFee sum of all fees in percentage as floating number, e.g. 0.99% should be supplied as 0.99
  * @returns total tokens amount that Contract will retrieve from the Sender
  */
-export const calculateTotalAmountToDeposit = (depositedAmount: BigNumber, totalFee: number): BigNumber => {
-  const totalFeeNormalized = BigNumber(totalFee * FEE_NORMALIZER);
-  return depositedAmount.times(totalFeeNormalized.plus(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
+export const calculateTotalAmountToDeposit = (depositedAmount: BN, totalFee: number): BN => {
+  const totalFeeNormalized = new BN(totalFee * FEE_NORMALIZER);
+  return depositedAmount.mul(totalFeeNormalized.add(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
 };
 
 /**

--- a/packages/stream/common/utils.ts
+++ b/packages/stream/common/utils.ts
@@ -1,4 +1,3 @@
-import BN from "bn.js";
 import BigNumber from "bignumber.js";
 
 import { ContractError } from "./types.js";
@@ -8,34 +7,28 @@ const FEE_NORMALIZER = 10 ** FEE_PRECISION;
 const FEE_MULTIPLIER = BigNumber(10 ** 6);
 
 /**
- * Used for conversion of token amounts to their Big Number representation.
- * Get Big Number representation in the smallest units from the same value in the highest units.
- * @param {number} value - Number of tokens you want to convert to its BN representation.
+ * Used for token amounts conversion from their Big Number representation to number.
+ * Get value in the highest units from BigNumber representation of the same value in the smallest units.
+ * @param {BigNumber} value - Big Number representation of value in the smallest units.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getBN = (value: number, decimals: number): BN => {
-  const decimalPart = value - Math.trunc(value);
-  const integerPart = new BN(Math.trunc(value));
-
-  const decimalE = new BN(decimalPart * 1e9);
-
-  const sum = integerPart.mul(new BN(1e9)).add(decimalE);
-  const resultE = sum.mul(new BN(10).pow(new BN(decimals)));
-  return resultE.div(new BN(1e9));
+export const getNumberFromBigNumber = (bigNum: BigNumber, decimals: number): number => {
+  return bigNum.div(BigNumber(10).pow(decimals)).toNumber();
 };
 
 /**
- * Used for token amounts conversion from their Big Number representation to number.
- * Get value in the highest units from BN representation of the same value in the smallest units.
- * @param {BN} value - Big Number representation of value in the smallest units.
+ * Used for conversion of token amounts to their Big Number representation.
+ * Get Big Number representation in the smallest units from the same value in the highest units.
+ * @param {number} value - Number of tokens you want to convert to its BigNumber representation.
  * @param {number} decimals - Number of decimals the token has.
  */
-export const getNumberFromBN = (value: BN, decimals: number): number =>
-  value.gt(new BN(2 ** 53 - 1)) ? value.div(new BN(10 ** decimals)).toNumber() : value.toNumber() / 10 ** decimals;
+export const getScaledBigNumber = (value: number | string | BigNumber, decimals: number): BigNumber => {
+  return new BigNumber(value).times(new BigNumber(10).pow(decimals));
+};
 
 /**
  * Calculate total amount of a Contract including all fees.
- * - first we convert fee floating to a BN with up to 4 decimals precision
+ * - first we convert fee floating to a BigNumber with up to 4 decimals precision
  * - then we reverse the fee with `FEE_MULTIPLIER` to safely multiply it by depositedAmount
  *   to receive a total number and not percentage of depositedAmount
  * @param depositedAmount deposited raw tokens

--- a/packages/stream/common/utils.ts
+++ b/packages/stream/common/utils.ts
@@ -1,10 +1,11 @@
 import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { ContractError } from "./types.js";
 
 const FEE_PRECISION = 4;
 const FEE_NORMALIZER = 10 ** FEE_PRECISION;
-const FEE_MULTIPLIER = new BN(10 ** 6);
+const FEE_MULTIPLIER = BigNumber(10 ** 6);
 
 /**
  * Used for conversion of token amounts to their Big Number representation.
@@ -41,9 +42,9 @@ export const getNumberFromBN = (value: BN, decimals: number): number =>
  * @param totalFee sum of all fees in percentage as floating number, e.g. 0.99% should be supplied as 0.99
  * @returns total tokens amount that Contract will retrieve from the Sender
  */
-export const calculateTotalAmountToDeposit = (depositedAmount: BN, totalFee: number): BN => {
-  const totalFeeNormalized = new BN(totalFee * FEE_NORMALIZER);
-  return depositedAmount.mul(totalFeeNormalized.add(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
+export const calculateTotalAmountToDeposit = (depositedAmount: BigNumber, totalFee: number): BigNumber => {
+  const totalFeeNormalized = BigNumber(totalFee).times(FEE_NORMALIZER);
+  return depositedAmount.times(totalFeeNormalized.plus(FEE_MULTIPLIER)).div(FEE_MULTIPLIER);
 };
 
 /**

--- a/packages/stream/evm/StreamClient.ts
+++ b/packages/stream/evm/StreamClient.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { toChecksumAddress } from "ethereum-checksum-address";
 
 import { BaseStreamClient } from "../common/BaseStreamClient.js";
@@ -89,7 +89,7 @@ export default class EvmStreamClient extends BaseStreamClient {
 
     const args = (await this.generateMultiPayloads(multiParams))[0];
 
-    const sum = streamData.amount.mul(new BN(BASE_FEE)).div(new BN(1000000));
+    const sum = streamData.amount.times(BigNumber(BASE_FEE)).div(BigNumber(1000000));
 
     await this.approveTokens(streamData.tokenId, sum);
 
@@ -116,9 +116,9 @@ export default class EvmStreamClient extends BaseStreamClient {
     const args = await this.generateMultiPayloads(multipleStreamData);
 
     const sum = multipleStreamData.recipients
-      .reduce((acc, v) => acc.add(v.amount), new BN(0))
-      .mul(new BN(BASE_FEE))
-      .div(new BN(1000000));
+      .reduce((acc, v) => acc.plus(v.amount), BigNumber(0))
+      .times(BigNumber(BASE_FEE))
+      .div(BigNumber(1000000));
     await this.approveTokens(multipleStreamData.tokenId, sum);
 
     const creationPromises = args.map((item) => this.writeContract.create(...item, { value: fees.value }));
@@ -189,7 +189,7 @@ export default class EvmStreamClient extends BaseStreamClient {
   public async topup(topupData: ITopUpData): Promise<ITransactionResult> {
     const fees = await this.readContract.getTopUpWithdrawalFees(topupData.id, topupData.amount.toString());
 
-    const sum = topupData.amount.mul(new BN(BASE_FEE)).div(new BN(1000000));
+    const sum = topupData.amount.times(BigNumber(BASE_FEE)).div(BigNumber(1000000));
 
     const stream = await this.getOne({ id: topupData.id });
 
@@ -268,11 +268,11 @@ export default class EvmStreamClient extends BaseStreamClient {
     return this.programId;
   }
 
-  public async approveTokens(tokenId: string, amount: BN): Promise<void> {
+  public async approveTokens(tokenId: string, amount: BigNumber): Promise<void> {
     const tokenContract = new ethers.Contract(tokenId, ercAbi, this.signer);
     const address = await this.signer.getAddress();
     const allowance = await tokenContract.allowance(address, this.programId);
-    if (new BN(allowance.toString()).gte(amount)) {
+    if (BigNumber(allowance.toString()).gte(amount)) {
       return;
     }
     const approvalTx = await tokenContract.approve(this.programId, amount.toString());

--- a/packages/stream/evm/types.ts
+++ b/packages/stream/evm/types.ts
@@ -1,8 +1,9 @@
 import BigNumber from "bignumber.js";
 import { BigNumber as BigNumberEvm } from "ethers";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
-import { Stream, StreamType } from "../common/types";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
+import { Stream, StreamType } from "../common/types.js";
+import { getNumberFromBigNumber } from "../common/utils.js";
 
 export interface StreamAbiResult {
   amount: BigNumberEvm;
@@ -194,9 +195,6 @@ export class EvmContract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return this.depositedAmount
-      .minus(this.withdrawnAmount)
-      .div(10 ** decimals)
-      .toNumber();
+    return getNumberFromBigNumber(this.depositedAmount.minus(this.withdrawnAmount), decimals);
   }
 }

--- a/packages/stream/evm/types.ts
+++ b/packages/stream/evm/types.ts
@@ -193,7 +193,10 @@ export class EvmContract implements Stream {
     });
   }
 
-  remaining(): number {
-    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
+  remaining(decimals: number): number {
+    return this.depositedAmount
+      .minus(this.withdrawnAmount)
+      .div(10 ** decimals)
+      .toNumber();
   }
 }

--- a/packages/stream/evm/types.ts
+++ b/packages/stream/evm/types.ts
@@ -1,31 +1,30 @@
-import BN from "bn.js";
-import { BigNumber } from "ethers";
+import BigNumber from "bignumber.js";
+import { BigNumber as BigNumberEvm } from "ethers";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
-import { Stream, StreamType } from "../common/types.js";
-import { getNumberFromBN } from "../common/utils.js";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
+import { Stream, StreamType } from "../common/types";
 
 export interface StreamAbiResult {
-  amount: BigNumber;
-  amount_per_period: BigNumber;
-  canceled_at: BigNumber;
-  cliff_amount: BigNumber;
+  amount: BigNumberEvm;
+  amount_per_period: BigNumberEvm;
+  canceled_at: BigNumberEvm;
+  cliff_amount: BigNumberEvm;
   closed: boolean;
-  created: BigNumber;
-  current_pause_start: BigNumber;
-  end: BigNumber;
+  created: BigNumberEvm;
+  current_pause_start: BigNumberEvm;
+  end: BigNumberEvm;
   fees: {
-    streamflow_fee_percentage: BigNumber;
-    streamflow_fee: BigNumber;
-    streamflow_fee_withdrawn: BigNumber;
-    partner_fee_percentage: BigNumber;
-    partner_fee: BigNumber;
-    partner_fee_withdrawn: BigNumber;
-    tx_fee: BigNumber;
+    streamflow_fee_percentage: BigNumberEvm;
+    streamflow_fee: BigNumberEvm;
+    streamflow_fee_withdrawn: BigNumberEvm;
+    partner_fee_percentage: BigNumberEvm;
+    partner_fee: BigNumberEvm;
+    partner_fee_withdrawn: BigNumberEvm;
+    tx_fee: BigNumberEvm;
   };
-  funds_unlocked_at_last_rate_change: BigNumber;
-  last_rate_change_time: BigNumber;
-  last_withdrawn_at: BigNumber;
+  funds_unlocked_at_last_rate_change: BigNumberEvm;
+  last_rate_change_time: BigNumberEvm;
+  last_withdrawn_at: BigNumberEvm;
   meta: {
     automatic_withdrawal: boolean;
     can_topup: boolean;
@@ -36,22 +35,22 @@ export interface StreamAbiResult {
     pausable: boolean;
     transferable_by_recipient: boolean;
     transferable_by_sender: boolean;
-    withdrawal_frequency: BigNumber;
+    withdrawal_frequency: BigNumberEvm;
   };
-  pause_cumulative: BigNumber;
-  period: BigNumber;
+  pause_cumulative: BigNumberEvm;
+  period: BigNumberEvm;
   recipient: string;
   sender: string;
   partner: string;
-  start: BigNumber;
+  start: BigNumberEvm;
   token: string;
-  withdrawn: BigNumber;
+  withdrawn: BigNumberEvm;
 }
 
 export interface FeesAbiResult {
   exists: boolean;
-  streamflow_fee: BigNumber;
-  partner_fee: BigNumber;
+  streamflow_fee: BigNumberEvm;
+  partner_fee: BigNumberEvm;
 }
 
 export class EvmContract implements Stream {
@@ -61,7 +60,7 @@ export class EvmContract implements Stream {
 
   createdAt: number;
 
-  withdrawnAmount: BN;
+  withdrawnAmount: BigNumber;
 
   canceledAt: number;
 
@@ -85,15 +84,15 @@ export class EvmContract implements Stream {
 
   streamflowTreasuryTokens: string;
 
-  streamflowFeeTotal: BN;
+  streamflowFeeTotal: BigNumber;
 
-  streamflowFeeWithdrawn: BN;
+  streamflowFeeWithdrawn: BigNumber;
 
   streamflowFeePercent: number;
 
-  partnerFeeTotal: BN;
+  partnerFeeTotal: BigNumber;
 
-  partnerFeeWithdrawn: BN;
+  partnerFeeWithdrawn: BigNumber;
 
   partnerFeePercent: number;
 
@@ -103,15 +102,15 @@ export class EvmContract implements Stream {
 
   start: number;
 
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
 
   period: number;
 
-  amountPerPeriod: BN;
+  amountPerPeriod: BigNumber;
 
   cliff: number;
 
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
 
   cancelableBySender: boolean;
 
@@ -133,11 +132,11 @@ export class EvmContract implements Stream {
 
   currentPauseStart: number;
 
-  pauseCumulative: BN;
+  pauseCumulative: BigNumber;
 
   lastRateChangeTime: number;
 
-  fundsUnlockedAtLastRateChange: BN;
+  fundsUnlockedAtLastRateChange: BigNumber;
 
   type: StreamType;
 
@@ -145,7 +144,7 @@ export class EvmContract implements Stream {
     this.magic = 0;
     this.version = 0;
     this.createdAt = stream.created.toNumber();
-    this.withdrawnAmount = new BN(stream.withdrawn.toString());
+    this.withdrawnAmount = BigNumber(stream.withdrawn.toString());
     this.canceledAt = stream.canceled_at.toNumber();
     this.end = stream.end.toNumber();
     this.lastWithdrawnAt = stream.last_withdrawn_at.toNumber();
@@ -157,20 +156,20 @@ export class EvmContract implements Stream {
     this.escrowTokens = "";
     this.streamflowTreasury = "";
     this.streamflowTreasuryTokens = "";
-    this.streamflowFeeTotal = new BN(stream.fees.streamflow_fee.toString());
-    this.streamflowFeeWithdrawn = new BN(stream.fees.streamflow_fee_withdrawn.toString());
+    this.streamflowFeeTotal = BigNumber(stream.fees.streamflow_fee.toString());
+    this.streamflowFeeWithdrawn = BigNumber(stream.fees.streamflow_fee_withdrawn.toString());
     this.streamflowFeePercent = stream.fees.streamflow_fee_percentage.toNumber() / 10000;
-    this.partnerFeeTotal = new BN(0);
-    this.partnerFeeWithdrawn = new BN(0);
+    this.partnerFeeTotal = BigNumber(0);
+    this.partnerFeeWithdrawn = BigNumber(0);
     this.partnerFeePercent = 0;
     this.partner = "";
     this.partnerTokens = "";
     this.start = stream.start.toNumber();
-    this.depositedAmount = new BN(stream.amount.toString());
+    this.depositedAmount = BigNumber(stream.amount.toString());
     this.period = stream.period.toNumber();
-    this.amountPerPeriod = new BN(stream.amount_per_period.toString());
+    this.amountPerPeriod = BigNumber(stream.amount_per_period.toString());
     this.cliff = stream.start.toNumber();
-    this.cliffAmount = new BN(stream.cliff_amount.toString());
+    this.cliffAmount = BigNumber(stream.cliff_amount.toString());
     this.cancelableBySender = stream.meta.cancelable_by_sender;
     this.cancelableByRecipient = stream.meta.cancelable_by_recipient;
     this.automaticWithdrawal = stream.meta.automatic_withdrawal;
@@ -181,20 +180,20 @@ export class EvmContract implements Stream {
     this.withdrawalFrequency = stream.meta.withdrawal_frequency.toNumber();
     this.closed = stream.closed;
     this.currentPauseStart = stream.current_pause_start.toNumber();
-    this.pauseCumulative = new BN(stream.pause_cumulative.toString());
+    this.pauseCumulative = BigNumber(stream.pause_cumulative.toString());
     this.lastRateChangeTime = stream.last_rate_change_time.toNumber();
-    this.fundsUnlockedAtLastRateChange = new BN(stream.funds_unlocked_at_last_rate_change.toString());
+    this.fundsUnlockedAtLastRateChange = BigNumber(stream.funds_unlocked_at_last_rate_change.toString());
     this.type = buildStreamType(this);
   }
 
-  unlocked(currentTimestamp: number): BN {
+  unlocked(currentTimestamp: number): BigNumber {
     return calculateUnlockedAmount({
       ...this,
       currentTimestamp,
     });
   }
 
-  remaining(decimals: number): number {
-    return getNumberFromBN(this.depositedAmount.sub(this.withdrawnAmount), decimals);
+  remaining(): number {
+    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
   }
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -61,6 +61,7 @@
     "@streamflow/common": "workspace:*",
     "@suiet/wallet-kit": "0.2.22",
     "aptos": "1.4.0",
+    "bignumber.js": "^9.1.2",
     "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -45,7 +45,6 @@
   "gitHead": "a37306eba0e762af096db642fa22f07194014cfd",
   "devDependencies": {
     "@streamflow/eslint-config": "workspace:*",
-    "@types/bn.js": "5.1.1",
     "@types/ethereum-checksum-address": "^0.0.0",
     "date-fns": "2.28.0",
     "typescript": "^5.3.3"
@@ -62,7 +61,6 @@
     "@suiet/wallet-kit": "0.2.22",
     "aptos": "1.4.0",
     "bignumber.js": "^9.1.2",
-    "bn.js": "5.2.1",
     "borsh": "^2.0.0",
     "bs58": "5.0.0",
     "ethereum-checksum-address": "0.0.8",

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -1,6 +1,6 @@
 // Latest version of the SDK that does not use Anchor. It supports raw instructions.
 
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { Buffer } from "buffer";
 import PQueue from "p-queue";
 import { ASSOCIATED_TOKEN_PROGRAM_ID, NATIVE_MINT } from "@solana/spl-token";
@@ -235,11 +235,11 @@ export class SolanaStreamClient extends BaseStreamClient {
     ixs.push(
       createStreamInstruction(
         {
-          start: new BN(start),
+          start: BigNumber(start),
           depositedAmount,
-          period: new BN(period),
+          period: BigNumber(period),
           amountPerPeriod,
-          cliff: new BN(cliff),
+          cliff: BigNumber(cliff),
           cliffAmount,
           cancelableBySender,
           cancelableByRecipient,
@@ -250,7 +250,7 @@ export class SolanaStreamClient extends BaseStreamClient {
           canUpdateRate: !!canUpdateRate,
           canPause: !!canPause,
           name,
-          withdrawFrequency: new BN(automaticWithdrawal ? withdrawalFrequency : period),
+          withdrawFrequency: BigNumber(automaticWithdrawal ? withdrawalFrequency : period),
         },
         this.programId,
         {
@@ -383,11 +383,11 @@ export class SolanaStreamClient extends BaseStreamClient {
 
     const createInstruction = createUncheckedStreamInstruction(
       {
-        start: new BN(start),
+        start: BigNumber(start),
         depositedAmount,
-        period: new BN(period),
+        period: BigNumber(period),
         amountPerPeriod,
-        cliff: new BN(cliff),
+        cliff: BigNumber(cliff),
         cliffAmount,
         cancelableBySender,
         cancelableByRecipient,
@@ -398,7 +398,7 @@ export class SolanaStreamClient extends BaseStreamClient {
         canUpdateRate: !!canUpdateRate,
         canPause: !!canPause,
         name,
-        withdrawFrequency: new BN(automaticWithdrawal ? withdrawalFrequency : period),
+        withdrawFrequency: BigNumber(automaticWithdrawal ? withdrawalFrequency : period),
         recipient: recipientPublicKey,
         partner: partnerPublicKey,
       },
@@ -483,7 +483,7 @@ export class SolanaStreamClient extends BaseStreamClient {
     }
 
     if (isNative) {
-      const totalDepositedAmount = recipients.reduce((acc, recipient) => recipient.amount.add(acc), new BN(0));
+      const totalDepositedAmount = recipients.reduce((acc, recipient) => recipient.amount.plus(acc), BigNumber(0));
       const nativeInstructions = await prepareWrappedAccount(this.connection, sender.publicKey, totalDepositedAmount);
 
       const messageV0 = new TransactionMessage({
@@ -1033,11 +1033,11 @@ export class SolanaStreamClient extends BaseStreamClient {
     ixs.push(
       createStreamInstruction(
         {
-          start: new BN(start),
+          start: BigNumber(start),
           depositedAmount: recipient.amount,
-          period: new BN(period),
+          period: BigNumber(period),
           amountPerPeriod: recipient.amountPerPeriod,
-          cliff: new BN(cliff),
+          cliff: BigNumber(cliff),
           cliffAmount: recipient.cliffAmount,
           cancelableBySender,
           cancelableByRecipient,
@@ -1048,7 +1048,7 @@ export class SolanaStreamClient extends BaseStreamClient {
           canUpdateRate: !!canUpdateRate,
           canPause: !!canPause,
           name: recipient.name,
-          withdrawFrequency: new BN(automaticWithdrawal ? withdrawalFrequency : period),
+          withdrawFrequency: BigNumber(automaticWithdrawal ? withdrawalFrequency : period),
         },
         this.programId,
         {

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -240,7 +240,7 @@ export class SolanaStreamClient extends BaseStreamClient {
           period: BigNumber(period),
           amountPerPeriod,
           cliff: BigNumber(cliff),
-          cliffAmount,
+          cliffAmount: BigNumber(cliffAmount),
           cancelableBySender,
           cancelableByRecipient,
           automaticWithdrawal,
@@ -388,7 +388,7 @@ export class SolanaStreamClient extends BaseStreamClient {
         period: BigNumber(period),
         amountPerPeriod,
         cliff: BigNumber(cliff),
-        cliffAmount,
+        cliffAmount: BigNumber(cliffAmount),
         cancelableBySender,
         cancelableByRecipient,
         automaticWithdrawal,
@@ -814,6 +814,7 @@ export class SolanaStreamClient extends BaseStreamClient {
     }
 
     ixs.push(
+      // ** 10
       topupStreamInstruction(amount, this.programId, {
         sender: invoker.publicKey,
         senderTokens,
@@ -1038,7 +1039,7 @@ export class SolanaStreamClient extends BaseStreamClient {
           period: BigNumber(period),
           amountPerPeriod: recipient.amountPerPeriod,
           cliff: BigNumber(cliff),
-          cliffAmount: recipient.cliffAmount,
+          cliffAmount: BigNumber(recipient.cliffAmount),
           cancelableBySender,
           cancelableByRecipient,
           automaticWithdrawal,

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -814,7 +814,6 @@ export class SolanaStreamClient extends BaseStreamClient {
     }
 
     ixs.push(
-      // ** 10
       topupStreamInstruction(amount, this.programId, {
         sender: invoker.publicKey,
         senderTokens,

--- a/packages/stream/solana/instructions.ts
+++ b/packages/stream/solana/instructions.ts
@@ -1,10 +1,11 @@
 import { Buffer } from "buffer";
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { createHash } from "node:crypto";
 
-import * as Layout from "./layout.js";
-import { IUpdateData } from "../common/types.js";
+import * as Layout from "./layout";
+import { IUpdateData } from "../common/types";
+import { toBuffer } from "./utils";
 
 const hasher = () => createHash("sha256");
 const sha256 = {
@@ -12,12 +13,12 @@ const sha256 = {
 };
 
 interface CreateStreamData {
-  start: BN;
-  depositedAmount: BN;
-  period: BN;
-  amountPerPeriod: BN;
-  cliff: BN;
-  cliffAmount: BN;
+  start: BigNumber;
+  depositedAmount: BigNumber;
+  period: BigNumber;
+  amountPerPeriod: BigNumber;
+  cliff: BigNumber;
+  cliffAmount: BigNumber;
   cancelableBySender: boolean;
   cancelableByRecipient: boolean;
   automaticWithdrawal: boolean;
@@ -27,7 +28,7 @@ interface CreateStreamData {
   canUpdateRate: boolean;
   canPause: boolean;
   name: string;
-  withdrawFrequency: BN;
+  withdrawFrequency: BigNumber;
 }
 
 interface CreateStreamAccounts {
@@ -95,12 +96,12 @@ export const createStreamInstruction = (
   const streamNameBuffer = Buffer.alloc(64).fill(encodedUIntArray, 0, encodedUIntArray.byteLength);
 
   const decodedData = {
-    start_time: data.start.toArrayLike(Buffer, "le", 8),
-    net_amount_deposited: data.depositedAmount.toArrayLike(Buffer, "le", 8),
-    period: data.period.toArrayLike(Buffer, "le", 8),
-    amount_per_period: data.amountPerPeriod.toArrayLike(Buffer, "le", 8),
-    cliff: data.cliff.toArrayLike(Buffer, "le", 8),
-    cliff_amount: data.cliffAmount.toArrayLike(Buffer, "le", 8),
+    start_time: toBuffer(data.start),
+    net_amount_deposited: toBuffer(data.depositedAmount),
+    period: toBuffer(data.period),
+    amount_per_period: toBuffer(data.amountPerPeriod),
+    cliff: toBuffer(data.cliff),
+    cliff_amount: toBuffer(data.cliffAmount),
     cancelable_by_sender: Number(data.cancelableBySender),
     cancelable_by_recipient: Number(data.cancelableByRecipient),
     automatic_withdrawal: Number(data.automaticWithdrawal),
@@ -112,7 +113,7 @@ export const createStreamInstruction = (
     _can_update_rate_discriminator: 1,
     pausable: Number(data.canPause),
     stream_name: streamNameBuffer,
-    withdraw_frequency: data.withdrawFrequency.toArrayLike(Buffer, "le", 8),
+    withdraw_frequency: toBuffer(data.withdrawFrequency),
   };
   const encodeLength = Layout.createStreamLayout.encode(decodedData, bufferData);
   bufferData = bufferData.slice(0, encodeLength);
@@ -126,12 +127,12 @@ export const createStreamInstruction = (
 };
 
 interface CreateUncheckedStreamData {
-  start: BN;
-  depositedAmount: BN;
-  period: BN;
-  amountPerPeriod: BN;
-  cliff: BN;
-  cliffAmount: BN;
+  start: BigNumber;
+  depositedAmount: BigNumber;
+  period: BigNumber;
+  amountPerPeriod: BigNumber;
+  cliff: BigNumber;
+  cliffAmount: BigNumber;
   cancelableBySender: boolean;
   cancelableByRecipient: boolean;
   automaticWithdrawal: boolean;
@@ -141,7 +142,7 @@ interface CreateUncheckedStreamData {
   canUpdateRate: boolean;
   canPause: boolean;
   name: string;
-  withdrawFrequency: BN;
+  withdrawFrequency: BigNumber;
   recipient: PublicKey;
   partner: PublicKey;
 }
@@ -194,12 +195,12 @@ export const createUncheckedStreamInstruction = (
   const streamNameBuffer = Buffer.alloc(64).fill(encodedUIntArray, 0, encodedUIntArray.byteLength);
 
   const decodedData = {
-    start_time: data.start.toArrayLike(Buffer, "le", 8),
-    net_amount_deposited: data.depositedAmount.toArrayLike(Buffer, "le", 8),
-    period: data.period.toArrayLike(Buffer, "le", 8),
-    amount_per_period: data.amountPerPeriod.toArrayLike(Buffer, "le", 8),
-    cliff: data.cliff.toArrayLike(Buffer, "le", 8),
-    cliff_amount: data.cliffAmount.toArrayLike(Buffer, "le", 8),
+    start_time: toBuffer(data.start),
+    net_amount_deposited: toBuffer(data.depositedAmount),
+    period: toBuffer(data.period),
+    amount_per_period: toBuffer(data.amountPerPeriod),
+    cliff: toBuffer(data.cliff),
+    cliff_amount: toBuffer(data.cliffAmount),
     cancelable_by_sender: Number(data.cancelableBySender),
     cancelable_by_recipient: Number(data.cancelableByRecipient),
     automatic_withdrawal: Number(data.automaticWithdrawal),
@@ -207,7 +208,7 @@ export const createUncheckedStreamInstruction = (
     transferable_by_recipient: Number(data.transferableByRecipient),
     can_topup: Number(data.canTopup),
     stream_name: streamNameBuffer,
-    withdraw_frequency: data.withdrawFrequency.toArrayLike(Buffer, "le", 8),
+    withdraw_frequency: toBuffer(data.withdrawFrequency),
     recipient: data.recipient.toBuffer(),
     partner: data.partner.toBuffer(),
     pausable: Number(data.canPause),
@@ -242,7 +243,7 @@ interface WithdrawAccounts {
 }
 
 export const withdrawStreamInstruction = (
-  amount: BN,
+  amount: BigNumber,
   programId: PublicKey,
   {
     authority,
@@ -277,7 +278,7 @@ export const withdrawStreamInstruction = (
   ];
 
   let data = Buffer.alloc(Layout.withdrawStreamLayout.span);
-  const decodedData = { amount: amount.toArrayLike(Buffer, "le", 8) };
+  const decodedData = { amount: toBuffer(amount) };
   const encodeLength = Layout.withdrawStreamLayout.encode(decodedData, data);
   data = data.slice(0, encodeLength);
   data = Buffer.concat([Buffer.from(sha256.digest("global:withdraw")).slice(0, 8), data, Buffer.alloc(10)]);
@@ -310,8 +311,8 @@ export const updateStreamInstruction = (
   let data = Buffer.alloc(100);
   const decodedData = {
     enable_automatic_withdrawal: Number(params.enableAutomaticWithdrawal),
-    withdraw_frequency: params.withdrawFrequency ? params.withdrawFrequency.toArrayLike(Buffer, "le", 8) : undefined,
-    amount_per_period: params.amountPerPeriod ? params.amountPerPeriod.toArrayLike(Buffer, "le", 8) : undefined,
+    withdraw_frequency: params.withdrawFrequency ? toBuffer(params.withdrawFrequency) : undefined,
+    amount_per_period: params.amountPerPeriod ? toBuffer(params.amountPerPeriod) : undefined,
   };
   const encodeLength = Layout.encodeUpdateStream(decodedData, data);
   data = data.slice(0, encodeLength);
@@ -449,7 +450,7 @@ interface TopupAccounts {
 }
 
 export const topupStreamInstruction = (
-  amount: BN,
+  amount: BigNumber,
   programId: PublicKey,
   {
     sender,
@@ -486,7 +487,7 @@ export const topupStreamInstruction = (
   ];
 
   let data = Buffer.alloc(Layout.topupStreamLayout.span);
-  const decodedData = { amount: amount.toArrayLike(Buffer, "le", 8) };
+  const decodedData = { amount: toBuffer(amount) };
 
   const encodeLength = Layout.topupStreamLayout.encode(decodedData, data);
   data = data.slice(0, encodeLength);

--- a/packages/stream/solana/instructions.ts
+++ b/packages/stream/solana/instructions.ts
@@ -3,9 +3,9 @@ import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
 import { createHash } from "node:crypto";
 
-import * as Layout from "./layout";
-import { IUpdateData } from "../common/types";
-import { toBuffer } from "./utils";
+import * as Layout from "./layout.js";
+import { IUpdateData } from "../common/types.js";
+import { toBuffer } from "./utils.js";
 
 const hasher = () => createHash("sha256");
 const sha256 = {

--- a/packages/stream/solana/types.ts
+++ b/packages/stream/solana/types.ts
@@ -1,7 +1,7 @@
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
 import { AccountInfo, PublicKey, Keypair, VersionedTransaction } from "@solana/web3.js";
 import { ITransactionSolanaExt } from "@streamflow/common/solana";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
 import { IRecipient, Stream, StreamType } from "../common/types.js";
@@ -40,7 +40,7 @@ export class Contract implements Stream {
 
   createdAt: number;
 
-  withdrawnAmount: BN;
+  withdrawnAmount: BigNumber;
 
   canceledAt: number;
 
@@ -64,15 +64,15 @@ export class Contract implements Stream {
 
   streamflowTreasuryTokens: string;
 
-  streamflowFeeTotal: BN;
+  streamflowFeeTotal: BigNumber;
 
-  streamflowFeeWithdrawn: BN;
+  streamflowFeeWithdrawn: BigNumber;
 
   streamflowFeePercent: number;
 
-  partnerFeeTotal: BN;
+  partnerFeeTotal: BigNumber;
 
-  partnerFeeWithdrawn: BN;
+  partnerFeeWithdrawn: BigNumber;
 
   partnerFeePercent: number;
 
@@ -82,15 +82,15 @@ export class Contract implements Stream {
 
   start: number;
 
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
 
   period: number;
 
-  amountPerPeriod: BN;
+  amountPerPeriod: BigNumber;
 
   cliff: number;
 
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
 
   cancelableBySender: boolean;
 
@@ -112,11 +112,11 @@ export class Contract implements Stream {
 
   currentPauseStart: number;
 
-  pauseCumulative: BN;
+  pauseCumulative: BigNumber;
 
   lastRateChangeTime: number;
 
-  fundsUnlockedAtLastRateChange: BN;
+  fundsUnlockedAtLastRateChange: BigNumber;
 
   type: StreamType;
 
@@ -166,7 +166,7 @@ export class Contract implements Stream {
     this.type = buildStreamType(this);
   }
 
-  unlocked(currentTimestamp: number): BN {
+  unlocked(currentTimestamp: number): BigNumber {
     return calculateUnlockedAmount({
       ...this,
       currentTimestamp,
@@ -174,18 +174,18 @@ export class Contract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return getNumberFromBN(this.depositedAmount.sub(this.withdrawnAmount), decimals);
+    return getNumberFromBN(this.depositedAmount.minus(this.withdrawnAmount), decimals);
   }
 }
 
 export interface DecodedStream {
-  magic: BN;
-  version: BN;
-  createdAt: BN;
-  withdrawnAmount: BN;
-  canceledAt: BN;
-  end: BN;
-  lastWithdrawnAt: BN;
+  magic: BigNumber;
+  version: BigNumber;
+  createdAt: BigNumber;
+  withdrawnAmount: BigNumber;
+  canceledAt: BigNumber;
+  end: BigNumber;
+  lastWithdrawnAt: BigNumber;
   sender: PublicKey;
   senderTokens: PublicKey;
   recipient: PublicKey;
@@ -194,20 +194,20 @@ export interface DecodedStream {
   escrowTokens: PublicKey;
   streamflowTreasury: PublicKey;
   streamflowTreasuryTokens: PublicKey;
-  streamflowFeeTotal: BN;
-  streamflowFeeWithdrawn: BN;
-  streamflowFeePercent: BN;
-  partnerFeeTotal: BN;
-  partnerFeeWithdrawn: BN;
-  partnerFeePercent: BN;
+  streamflowFeeTotal: BigNumber;
+  streamflowFeeWithdrawn: BigNumber;
+  streamflowFeePercent: BigNumber;
+  partnerFeeTotal: BigNumber;
+  partnerFeeWithdrawn: BigNumber;
+  partnerFeePercent: BigNumber;
   partner: PublicKey;
   partnerTokens: PublicKey;
-  start: BN;
-  depositedAmount: BN;
-  period: BN;
-  amountPerPeriod: BN;
-  cliff: BN;
-  cliffAmount: BN;
+  start: BigNumber;
+  depositedAmount: BigNumber;
+  period: BigNumber;
+  amountPerPeriod: BigNumber;
+  cliff: BigNumber;
+  cliffAmount: BigNumber;
   cancelableBySender: boolean;
   cancelableByRecipient: boolean;
   automaticWithdrawal: boolean;
@@ -215,12 +215,12 @@ export interface DecodedStream {
   transferableByRecipient: boolean;
   canTopup: boolean;
   name: string;
-  withdrawFrequency: BN;
+  withdrawFrequency: BigNumber;
   closed: boolean;
-  currentPauseStart: BN;
-  pauseCumulative: BN;
-  lastRateChangeTime: BN;
-  fundsUnlockedAtLastRateChange: BN;
+  currentPauseStart: BigNumber;
+  pauseCumulative: BigNumber;
+  lastRateChangeTime: BigNumber;
+  fundsUnlockedAtLastRateChange: BigNumber;
 }
 
 export interface MetadataRecipientHashMap {

--- a/packages/stream/solana/types.ts
+++ b/packages/stream/solana/types.ts
@@ -5,6 +5,7 @@ import BigNumber from "bignumber.js";
 
 import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
 import { IRecipient, Stream, StreamType } from "../common/types.js";
+import { getNumberFromBigNumber } from "../common/utils.js";
 
 export interface Account {
   pubkey: PublicKey;
@@ -173,10 +174,7 @@ export class Contract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return this.depositedAmount
-      .minus(this.withdrawnAmount)
-      .div(10 ** decimals)
-      .toNumber();
+    return getNumberFromBigNumber(this.depositedAmount.minus(this.withdrawnAmount), decimals);
   }
 }
 

--- a/packages/stream/solana/types.ts
+++ b/packages/stream/solana/types.ts
@@ -5,7 +5,6 @@ import BigNumber from "bignumber.js";
 
 import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
 import { IRecipient, Stream, StreamType } from "../common/types.js";
-import { getNumberFromBN } from "../common/utils.js";
 
 export interface Account {
   pubkey: PublicKey;
@@ -174,7 +173,10 @@ export class Contract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return getNumberFromBN(this.depositedAmount.minus(this.withdrawnAmount), decimals);
+    return this.depositedAmount
+      .minus(this.withdrawnAmount)
+      .div(10 ** decimals)
+      .toNumber();
   }
 }
 

--- a/packages/stream/solana/utils.ts
+++ b/packages/stream/solana/utils.ts
@@ -16,13 +16,14 @@ import { SOLANA_ERROR_MAP, SOLANA_ERROR_MATCH_REGEX } from "./constants.js";
 const decoder = new TextDecoder("utf-8");
 
 const toUInt64String = (uintArr: Uint8Array): string =>
-  new DataView(uintArr.buffer, 0).getBigUint64(0, true).toString();
+  new DataView(uintArr.buffer, uintArr.byteOffset, uintArr.byteLength).getBigUint64(0, true).toString();
 
-const toUInt8 = (uintArr: Uint8Array): number => new DataView(uintArr.buffer, 0).getUint8(0);
+const toUInt8 = (uintArr: Uint8Array): number =>
+  new DataView(uintArr.buffer, uintArr.byteOffset, uintArr.byteLength).getUint8(0);
 
 export const toBuffer = (bigNumber: BigNumber): Buffer => {
   const dv = new DataView(new ArrayBuffer(8), 0);
-  dv.setBigUint64(0, BigInt(bigNumber.toString()), true);
+  dv.setBigUint64(0, BigInt(bigNumber.integerValue().toString()), true);
   return Buffer.from(dv.buffer);
 };
 

--- a/packages/stream/solana/utils.ts
+++ b/packages/stream/solana/utils.ts
@@ -7,26 +7,36 @@ import {
   isSignerWallet,
   ThrottleParams,
 } from "@streamflow/common/solana";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
 import { streamLayout } from "./layout.js";
 import { DecodedStream, BatchItem, BatchItemResult } from "./types.js";
 import { SOLANA_ERROR_MAP, SOLANA_ERROR_MATCH_REGEX } from "./constants.js";
 
 const decoder = new TextDecoder("utf-8");
-const LE = "le"; //little endian
+
+const toUInt64String = (uintArr: Uint8Array): string =>
+  new DataView(uintArr.buffer, 0).getBigUint64(0, true).toString();
+
+const toUInt8 = (uintArr: Uint8Array): number => new DataView(uintArr.buffer, 0).getUint8(0);
+
+export const toBuffer = (bigNumber: BigNumber): Buffer => {
+  const dv = new DataView(new ArrayBuffer(8), 0);
+  dv.setBigUint64(0, BigInt(bigNumber.toString()), true);
+  return Buffer.from(dv.buffer);
+};
 
 export const decodeStream = (buf: Buffer): DecodedStream => {
   const raw = streamLayout.decode(buf);
 
   return {
-    magic: new BN(raw.magic, LE),
-    version: new BN(raw.version, LE),
-    createdAt: new BN(raw.created_at, LE),
-    withdrawnAmount: new BN(raw.withdrawn_amount, LE),
-    canceledAt: new BN(raw.canceled_at, LE),
-    end: new BN(raw.end_time, LE),
-    lastWithdrawnAt: new BN(raw.last_withdrawn_at, LE),
+    magic: BigNumber(toUInt64String(raw.magic)),
+    version: BigNumber(toUInt8(raw.version)),
+    createdAt: BigNumber(toUInt64String(raw.created_at)),
+    withdrawnAmount: BigNumber(toUInt64String(raw.withdrawn_amount)),
+    canceledAt: BigNumber(toUInt64String(raw.canceled_at)),
+    end: BigNumber(toUInt64String(raw.end_time)),
+    lastWithdrawnAt: BigNumber(toUInt64String(raw.last_withdrawn_at)),
     sender: new PublicKey(raw.sender),
     senderTokens: new PublicKey(raw.sender_tokens),
     recipient: new PublicKey(raw.recipient),
@@ -35,20 +45,20 @@ export const decodeStream = (buf: Buffer): DecodedStream => {
     escrowTokens: new PublicKey(raw.escrow_tokens),
     streamflowTreasury: new PublicKey(raw.streamflow_treasury),
     streamflowTreasuryTokens: new PublicKey(raw.streamflow_treasury_tokens),
-    streamflowFeeTotal: new BN(raw.streamflow_fee_total, LE),
-    streamflowFeeWithdrawn: new BN(raw.streamflow_fee_withdrawn, LE),
-    streamflowFeePercent: new BN(raw.streamflow_fee_percent, LE),
-    partnerFeeTotal: new BN(raw.partner_fee_total, LE),
-    partnerFeeWithdrawn: new BN(raw.partner_fee_withdrawn, LE),
-    partnerFeePercent: new BN(raw.partner_fee_percent, LE),
+    streamflowFeeTotal: BigNumber(toUInt64String(raw.streamflow_fee_total)),
+    streamflowFeeWithdrawn: BigNumber(toUInt64String(raw.streamflow_fee_withdrawn)),
+    streamflowFeePercent: BigNumber(raw.streamflow_fee_percent), //maybe not good
+    partnerFeeTotal: BigNumber(toUInt64String(raw.partner_fee_total)),
+    partnerFeeWithdrawn: BigNumber(toUInt64String(raw.partner_fee_withdrawn)),
+    partnerFeePercent: BigNumber(raw.partner_fee_percent), //maybe not good
     partner: new PublicKey(raw.partner),
     partnerTokens: new PublicKey(raw.partner_tokens),
-    start: new BN(raw.start_time, LE),
-    depositedAmount: new BN(raw.net_amount_deposited, LE),
-    period: new BN(raw.period, LE),
-    amountPerPeriod: new BN(raw.amount_per_period, LE),
-    cliff: new BN(raw.cliff, LE),
-    cliffAmount: new BN(raw.cliff_amount, LE),
+    start: BigNumber(toUInt64String(raw.start_time)),
+    depositedAmount: BigNumber(toUInt64String(raw.net_amount_deposited)),
+    period: BigNumber(toUInt64String(raw.period)),
+    amountPerPeriod: BigNumber(toUInt64String(raw.amount_per_period)),
+    cliff: BigNumber(toUInt64String(raw.cliff)),
+    cliffAmount: BigNumber(toUInt64String(raw.cliff_amount)),
     cancelableBySender: Boolean(raw.cancelable_by_sender),
     cancelableByRecipient: Boolean(raw.cancelable_by_recipient),
     automaticWithdrawal: Boolean(raw.automatic_withdrawal),
@@ -56,12 +66,12 @@ export const decodeStream = (buf: Buffer): DecodedStream => {
     transferableByRecipient: Boolean(raw.transferable_by_recipient),
     canTopup: Boolean(raw.can_topup),
     name: decoder.decode(raw.stream_name),
-    withdrawFrequency: new BN(raw.withdraw_frequency, LE),
+    withdrawFrequency: BigNumber(toUInt64String(raw.withdraw_frequency)),
     closed: Boolean(raw.closed),
-    currentPauseStart: new BN(raw.current_pause_start, LE),
-    pauseCumulative: new BN(raw.pause_cumulative, LE),
-    lastRateChangeTime: new BN(raw.last_rate_change_time, LE),
-    fundsUnlockedAtLastRateChange: new BN(raw.funds_unlocked_at_last_rate_change, LE),
+    currentPauseStart: BigNumber(toUInt64String(raw.current_pause_start)),
+    pauseCumulative: BigNumber(toUInt64String(raw.pause_cumulative)),
+    lastRateChangeTime: BigNumber(toUInt64String(raw.last_rate_change_time)),
+    fundsUnlockedAtLastRateChange: BigNumber(toUInt64String(raw.funds_unlocked_at_last_rate_change)),
   };
 };
 

--- a/packages/stream/solana/utils.ts
+++ b/packages/stream/solana/utils.ts
@@ -48,10 +48,10 @@ export const decodeStream = (buf: Buffer): DecodedStream => {
     streamflowTreasuryTokens: new PublicKey(raw.streamflow_treasury_tokens),
     streamflowFeeTotal: BigNumber(toUInt64String(raw.streamflow_fee_total)),
     streamflowFeeWithdrawn: BigNumber(toUInt64String(raw.streamflow_fee_withdrawn)),
-    streamflowFeePercent: BigNumber(raw.streamflow_fee_percent), //maybe not good
+    streamflowFeePercent: BigNumber(raw.streamflow_fee_percent),
     partnerFeeTotal: BigNumber(toUInt64String(raw.partner_fee_total)),
     partnerFeeWithdrawn: BigNumber(toUInt64String(raw.partner_fee_withdrawn)),
-    partnerFeePercent: BigNumber(raw.partner_fee_percent), //maybe not good
+    partnerFeePercent: BigNumber(raw.partner_fee_percent),
     partner: new PublicKey(raw.partner),
     partnerTokens: new PublicKey(raw.partner_tokens),
     start: BigNumber(toUInt64String(raw.start_time)),

--- a/packages/stream/sui/StreamClient.ts
+++ b/packages/stream/sui/StreamClient.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 import { CoinStruct, SuiClient } from "@mysten/sui.js/client";
 import { TransactionBlock, TransactionObjectArgument } from "@mysten/sui.js/transactions";
 import { SUI_CLOCK_OBJECT_ID, SUI_TYPE_ARG } from "@mysten/sui.js/utils";
@@ -420,7 +420,7 @@ export default class SuiStreamClient extends BaseStreamClient {
     let coins = await this.getAllCoins(walletAddress, multipleStreamData.tokenId);
     const totalAmount = multipleStreamData.recipients
       .map((recipiient) => recipiient.amount)
-      .reduce((prev, current) => current.add(prev));
+      .reduce((prev, current) => current.plus(prev));
     const txb = new TransactionBlock();
     const coinObject = this.splitCoinObjectForAmount(txb, totalAmount, multipleStreamData.tokenId, coins, totalFee);
     coins = [coins[0]];
@@ -498,7 +498,7 @@ export default class SuiStreamClient extends BaseStreamClient {
    */
   private splitCoinObjectForAmount(
     txb: TransactionBlock,
-    amount: BN,
+    amount: BigNumber,
     coinType: string,
     coins: CoinStruct[],
     totalFee: number,

--- a/packages/stream/sui/types.ts
+++ b/packages/stream/sui/types.ts
@@ -2,11 +2,10 @@ import { Keypair } from "@mysten/sui.js/cryptography";
 import { WalletContextState } from "@suiet/wallet-kit";
 import { TransactionBlock } from "@mysten/sui.js/transactions";
 import { ExecuteTransactionRequestType, SuiTransactionBlockResponseOptions } from "@mysten/sui.js/client";
-import BN from "bn.js";
+import BigNumber from "bignumber.js";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
-import { Stream, StreamType } from "../common/types.js";
-import { getNumberFromBN } from "../common/utils.js";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
+import { Stream, StreamType } from "../common/types";
 
 export interface ICreateStreamSuiExt {
   senderWallet: WalletContextState | Keypair;
@@ -120,7 +119,7 @@ export class Contract implements Stream {
 
   createdAt: number;
 
-  withdrawnAmount: BN;
+  withdrawnAmount: BigNumber;
 
   canceledAt: number;
 
@@ -144,15 +143,15 @@ export class Contract implements Stream {
 
   streamflowTreasuryTokens: string;
 
-  streamflowFeeTotal: BN;
+  streamflowFeeTotal: BigNumber;
 
-  streamflowFeeWithdrawn: BN;
+  streamflowFeeWithdrawn: BigNumber;
 
   streamflowFeePercent: number;
 
-  partnerFeeTotal: BN;
+  partnerFeeTotal: BigNumber;
 
-  partnerFeeWithdrawn: BN;
+  partnerFeeWithdrawn: BigNumber;
 
   partnerFeePercent: number;
 
@@ -162,15 +161,15 @@ export class Contract implements Stream {
 
   start: number;
 
-  depositedAmount: BN;
+  depositedAmount: BigNumber;
 
   period: number;
 
-  amountPerPeriod: BN;
+  amountPerPeriod: BigNumber;
 
   cliff: number;
 
-  cliffAmount: BN;
+  cliffAmount: BigNumber;
 
   cancelableBySender: boolean;
 
@@ -192,11 +191,11 @@ export class Contract implements Stream {
 
   currentPauseStart: number;
 
-  pauseCumulative: BN;
+  pauseCumulative: BigNumber;
 
   lastRateChangeTime: number;
 
-  fundsUnlockedAtLastRateChange: BN;
+  fundsUnlockedAtLastRateChange: BigNumber;
 
   type: StreamType;
 
@@ -207,7 +206,7 @@ export class Contract implements Stream {
     this.magic = 0;
     this.version = parseInt(stream.version);
     this.createdAt = parseInt(stream.created);
-    this.withdrawnAmount = new BN(stream.withdrawn);
+    this.withdrawnAmount = BigNumber(stream.withdrawn);
     this.canceledAt = parseInt(stream.canceled_at);
     this.end = parseInt(stream.end);
     this.lastWithdrawnAt = parseInt(stream.last_withdrawn_at);
@@ -219,20 +218,20 @@ export class Contract implements Stream {
     this.escrowTokens = "";
     this.streamflowTreasury = "";
     this.streamflowTreasuryTokens = "";
-    this.streamflowFeeTotal = new BN(0);
-    this.streamflowFeeWithdrawn = new BN(0);
+    this.streamflowFeeTotal = BigNumber(0);
+    this.streamflowFeeWithdrawn = BigNumber(0);
     this.streamflowFeePercent = parseInt(fees.streamflow_fee_percentage) / 10000;
-    this.partnerFeeTotal = new BN(0);
-    this.partnerFeeWithdrawn = new BN(0);
+    this.partnerFeeTotal = BigNumber(0);
+    this.partnerFeeWithdrawn = BigNumber(0);
     this.partnerFeePercent = parseInt(fees.partner_fee_percentage) / 10000;
     this.partner = stream.partner;
     this.partnerTokens = "";
     this.start = parseInt(stream.start);
-    this.depositedAmount = new BN(stream.amount);
+    this.depositedAmount = BigNumber(stream.amount);
     this.period = parseInt(stream.period);
-    this.amountPerPeriod = new BN(stream.amount_per_period);
+    this.amountPerPeriod = BigNumber(stream.amount_per_period);
     this.cliff = parseInt(stream.start);
-    this.cliffAmount = new BN(stream.cliff_amount);
+    this.cliffAmount = BigNumber(stream.cliff_amount);
     this.cancelableBySender = meta.cancelable_by_sender;
     this.cancelableByRecipient = meta.cancelable_by_recipient;
     this.automaticWithdrawal = meta.automatic_withdrawal;
@@ -243,21 +242,21 @@ export class Contract implements Stream {
     this.withdrawalFrequency = parseInt(meta.withdrawal_frequency);
     this.closed = stream.closed;
     this.currentPauseStart = parseInt(stream.current_pause_start);
-    this.pauseCumulative = new BN(stream.pause_cumulative);
+    this.pauseCumulative = BigNumber(stream.pause_cumulative);
     this.lastRateChangeTime = parseInt(stream.last_rate_change_time);
-    this.fundsUnlockedAtLastRateChange = new BN(stream.funds_unlocked_at_last_rate_change);
+    this.fundsUnlockedAtLastRateChange = BigNumber(stream.funds_unlocked_at_last_rate_change);
     this.type = buildStreamType(this);
   }
 
-  unlocked(currentTimestamp: number): BN {
+  unlocked(currentTimestamp: number): BigNumber {
     return calculateUnlockedAmount({
       ...this,
       currentTimestamp,
     });
   }
 
-  remaining(decimals: number): number {
-    return getNumberFromBN(this.depositedAmount.sub(this.withdrawnAmount), decimals);
+  remaining(): number {
+    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
   }
 }
 

--- a/packages/stream/sui/types.ts
+++ b/packages/stream/sui/types.ts
@@ -255,8 +255,11 @@ export class Contract implements Stream {
     });
   }
 
-  remaining(): number {
-    return this.depositedAmount.minus(this.withdrawnAmount).toNumber();
+  remaining(decimals: number): number {
+    return this.depositedAmount
+      .minus(this.withdrawnAmount)
+      .div(10 ** decimals)
+      .toNumber();
   }
 }
 

--- a/packages/stream/sui/types.ts
+++ b/packages/stream/sui/types.ts
@@ -4,8 +4,9 @@ import { TransactionBlock } from "@mysten/sui.js/transactions";
 import { ExecuteTransactionRequestType, SuiTransactionBlockResponseOptions } from "@mysten/sui.js/client";
 import BigNumber from "bignumber.js";
 
-import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils";
-import { Stream, StreamType } from "../common/types";
+import { buildStreamType, calculateUnlockedAmount } from "../common/contractUtils.js";
+import { Stream, StreamType } from "../common/types.js";
+import { getNumberFromBigNumber } from "../common/utils.js";
 
 export interface ICreateStreamSuiExt {
   senderWallet: WalletContextState | Keypair;
@@ -256,10 +257,7 @@ export class Contract implements Stream {
   }
 
   remaining(decimals: number): number {
-    return this.depositedAmount
-      .minus(this.withdrawnAmount)
-      .div(10 ** decimals)
-      .toNumber();
+    return getNumberFromBigNumber(this.depositedAmount.minus(this.withdrawnAmount), decimals);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
-      bn.js:
-        specifier: 5.2.1
-        version: 5.2.1
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
@@ -72,9 +69,6 @@ importers:
       '@streamflow/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
-      '@types/bn.js':
-        specifier: 5.1.1
-        version: 5.1.1
       date-fns:
         specifier: 2.28.0
         version: 2.28.0
@@ -105,9 +99,6 @@ importers:
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
-      bn.js:
-        specifier: 5.2.1
-        version: 5.2.1
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
@@ -121,9 +112,6 @@ importers:
       '@streamflow/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
-      '@types/bn.js':
-        specifier: 5.1.1
-        version: 5.1.1
       date-fns:
         specifier: 2.28.0
         version: 2.28.0
@@ -187,9 +175,6 @@ importers:
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
-      bn.js:
-        specifier: 5.2.1
-        version: 5.2.1
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
@@ -209,9 +194,6 @@ importers:
       '@streamflow/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
-      '@types/bn.js':
-        specifier: 5.1.1
-        version: 5.1.1
       '@types/ethereum-checksum-address':
         specifier: ^0.0.0
         version: 0.0.0
@@ -1918,9 +1900,6 @@ packages:
   '@tufjs/models@1.0.4':
     resolution: {integrity: sha512-qaGV9ltJP0EO25YfFUPhxRVK0evXFIAGicsVXuRim4Ed9cjPxYhNnNJ49SFmbeLgtxpslIkX317IgpfcHPVj/A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  '@types/bn.js@5.1.1':
-    resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -7645,10 +7624,6 @@ snapshots:
     dependencies:
       '@tufjs/canonical-json': 1.0.0
       minimatch: 9.0.3
-
-  '@types/bn.js@5.1.1':
-    dependencies:
-      '@types/node': 20.11.19
 
   '@types/connect@3.4.38':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       aptos:
         specifier: 1.4.0
         version: 1.4.0
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       bn.js:
         specifier: 5.2.1
         version: 5.2.1
@@ -99,6 +102,9 @@ importers:
       '@streamflow/common':
         specifier: workspace:*
         version: link:../common
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       bn.js:
         specifier: 5.2.1
         version: 5.2.1
@@ -178,6 +184,9 @@ importers:
       aptos:
         specifier: 1.4.0
         version: 1.4.0
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       bn.js:
         specifier: 5.2.1
         version: 5.2.1


### PR DESCRIPTION
Overview
We want to switch to using bignumber.js library due to more precision when doing operations like division and multiplication and to have consistency across the codebases (to only use 1 big number library).

Addressing comments by @LukaStreamflow on original PR
https://github.com/streamflow-finance/js-sdk/pull/186#discussion_r1740582855
I don't see this function being called anywhere in js-sdk or our app? - no reason to change it
https://github.com/streamflow-finance/js-sdk/pull/186#discussion_r1740588657
We are dropping support for EVM AFAIK - I created a to-do to remove this once safe

Other comments are resolved