### PR TITLE
Add ESLint rule for BN imports

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,19 +2,4 @@
 
 . "$(dirname -- "$0")/_/husky.sh"
 
-TARGET_FOLDER="packages/distributor/solana/generated" 
-
-OS=$(uname)
-
-echo "Replacing 'BN' with 'BigNumber' in $TARGET_FOLDER and its subfolders"
-if [ "$OS" = "Darwin" ]; then
-    SED_NO_BACKUP=( -i '' )
-else
-    SED_NO_BACKUP=( -i )
-fi
-
-find "$TARGET_FOLDER" -type f -name "*.ts" -exec sed "${SED_NO_BACKUP[@]}" -e 's/BN/BigNumber/g' -e 's/bn/bignumber/g' {} +
-
-git add $TARGET_FOLDER
-
 npm run lint

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "local-publish": "lerna publish --no-git-tag-version --no-push --registry=\"http://localhost:4873/\" from-package --yes",
     "local-unpublish": "lerna exec -- npm unpublish --registry=\"http://localhost:4873/\" \"\\${LERNA_PACKAGE_NAME}@\\$(npm view \\$LERNA_PACKAGE_NAME version)\"",
     "local-unpublish-all": "lerna exec -- npm unpublish -f --registry=\"http://localhost:4873/\" \"\\${LERNA_PACKAGE_NAME}\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "convert-bn": "./scripts/convertBN.sh"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.3",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -19,6 +19,13 @@ module.exports = {
   },
   ignorePatterns: ["**/dist/**/*"],
   rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "bn.js",
+        message: "We no longer use BN.js for big number calculations. Switch to using bignumber.js instead. Run npm run convert-bn to automatically switch BN to BigNumber in all folders"
+      }
+    ],
     "prettier/prettier": [
       "error",
       {

--- a/scripts/convertBN.sh
+++ b/scripts/convertBN.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+TARGET_FOLDERS=$@
+
+OS=$(uname)
+
+if [ "$OS" = "Darwin" ]; then
+    SED_NO_BACKUP=( -i '' )
+else
+    SED_NO_BACKUP=( -i )
+fi
+
+for FOLDER in $TARGET_FOLDERS
+do
+echo "Replacing 'BN' with 'BigNumber' in $FOLDER and its subfolders"
+find "$FOLDER" -type f -name "*.ts[x]" -exec sed "${SED_NO_BACKUP[@]}" -e 's/BN/BigNumber/g' -e 's/bn/bignumber/g' {} +
+done

--- a/scripts/convertBN.sh
+++ b/scripts/convertBN.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-TARGET_FOLDERS=$@
+if [ $# -eq 0 ]; then
+  TARGET_FOLDERS="packages"
+else
+  TARGET_FOLDERS=$@
+fi
 
 OS=$(uname)
 


### PR DESCRIPTION
- Added ESLint rule to prevent bn.js imports
- pre-commit hook no longer converts BN to BigNumber, now the script can be manually run like `npm run convert-bn` to run on all files under `packages` or you can specify the folders e.g `npm run convert-bn -- packages/stream/solana`
