### PR TITLE
Deprecated Solana calls + Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo consists of js-sdk to interact with several protocol exposed by stream
 
 ## Installation
 
-### Instal Stream Protocol SDK
+### Install Stream Protocol SDK
 
 `npm i -s @streamflow/stream`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are several ways to use **Streamflow**:
 **Security audit passed ✅**
 
 Protocol audits available [here](https://www.notion.so/streamflow/Streamflow-Security-Audits-3250070c0b3a4a0690385d96316d645c).  
-Partner oracle audit available here [here](https://github.com/streamflow-finance/rust-sdk/blob/main/partner_oracle_audit.pdf).
+Partner oracle audit available [here](https://github.com/streamflow-finance/rust-sdk/blob/main/partner_oracle_audit.pdf).
 
 ## Documentation
 API Documentation available here: [docs site →](https://streamflow-finance.github.io/js-sdk/)
@@ -20,27 +20,26 @@ API Documentation available here: [docs site →](https://streamflow-finance.git
 
 This repo consists of js-sdk to interact with several protocol exposed by streamflow:
 - `packages/stream` - [Core Streamflow Protocol](packages/stream/README.md) that allows to create a vesting/payment/lock Stream to a Recipient;
-- `packages/distributor` - [Distirbutor Streamflow Protocol](packages/distributor/README.md) that allows to Airdrop tokens to large amount of Recipients (thousands or even millions);
+- `packages/distributor` - [Distributor Streamflow Protocol](packages/distributor/README.md) that allows to Airdrop tokens to large amount of Recipients (thousands or even millions);
 - `packages/common` - Common utilities and types used by Streamflow SDK;
 
 ## Installation
 
 ### Install Stream Protocol SDK
 
-`npm i -s @streamflow/stream`
-
-or
-
-`yarn add @streamflow/stream`
-
+```bash
+npm i -s @streamflow/stream
+# or
+yarn add @streamflow/stream
+```
 
 ### Install Distributor Protocol SDK
 
-`npm i -s @streamflow/common @streamflow/distributor`
-
-or
-
-`yarn add @streamflow/common @streamflow/distributor`
+```bash
+npm i -s @streamflow/common @streamflow/distributor
+# or
+yarn add @streamflow/common @streamflow/distributor
+```
 
 ## Contributing
 
@@ -50,11 +49,11 @@ To contribute to this repository, please follow these steps:
 2. Clone your forked repository
 3. Navigate to the `/packages` folder
 4. Install dependencies using pnpm:
-   ```
+   ```bash
    pnpm install
    ```
 5. Build the project:
-   ```
+   ```bash
    pnpm build
    ```
 6. Make your changes

--- a/README.md
+++ b/README.md
@@ -41,3 +41,24 @@ or
 or
 
 `yarn add @streamflow/common @streamflow/distributor`
+
+## Contributing
+
+To contribute to this repository, please follow these steps:
+
+1. Fork the repository
+2. Clone your forked repository
+3. Navigate to the `/packages` folder
+4. Install dependencies using pnpm:
+   ```
+   pnpm install
+   ```
+5. Build the project:
+   ```
+   pnpm build
+   ```
+6. Make your changes
+7. Commit and push your changes
+8. Create a pull request
+
+Please ensure that you have [pnpm](https://pnpm.io/) installed on your system before contributing.

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.4",
+  "version": "6.5.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "6.4.4",
+  "version": "6.5.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/common/solana/utils.ts
+++ b/packages/common/solana/utils.ts
@@ -347,11 +347,11 @@ export async function confirmAndEnsureTransaction(
   signature: string,
   ignoreError?: boolean,
 ): Promise<SignatureStatus | null> {
-  const response = await connection.getSignatureStatus(signature);
-  if (!response) {
+  const response = await connection.getSignatureStatuses([signature]);
+  if (!response || response.value.length === 0 || response.value[0] === null) {
     return null;
   }
-  const { value } = response;
+  const value = response.value[0];
   if (!value) {
     return null;
   }

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "6.4.4",
+  "version": "6.5.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "6.4.4",
+  "version": "6.5.0",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "6.4.4",
+  "version": "6.5.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/index.js",


### PR DESCRIPTION
Solana will deprecate some calls:
https://docs.triton.one/chains/solana/deprecated-calls-solana-2.0

In this PR they are changed with updated ones.

Piggybacked:
Readme type + Contribution + A bit of styling