### PR TITLE
Expose distributor program ids 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -103,6 +103,10 @@ export default abstract class BaseDistributorClient {
     return typeof this.commitment == "string" ? this.commitment : this.commitment.commitment;
   }
 
+  public getDistributorProgramId(): PublicKey {
+    return this.programId;
+  }
+
   public async prepareCreateInstructions(
     data: ICreateDistributorData | ICreateAlignedDistributorData,
     extParams: ICreateSolanaExt,

--- a/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
@@ -32,9 +32,13 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
     return this.alignedProxyProgram.programId;
   }
 
-  public async getAlignedDistributorData(distributorAddress: string): Promise<AlignedDistributorData> {
+  public getAlignedDistributorAddress(distributorAddress: string): PublicKey {
     const distributorKey = new PublicKey(distributorAddress);
-    const alignedDistributorKey = getAlignedDistributorPda(this.alignedProxyProgram.programId, distributorKey);
+    return getAlignedDistributorPda(this.alignedProxyProgram.programId, distributorKey);
+  }
+
+  public async getAlignedDistributorData(distributorAddress: string): Promise<AlignedDistributorData> {
+    const alignedDistributorKey = this.getAlignedDistributorAddress(distributorAddress);
     const alignedProxy = await this.alignedProxyProgram.account.alignedDistributor.fetch(alignedDistributorKey);
     invariant(alignedProxy, "Aligned Distributor proxy account not found");
 

--- a/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
@@ -28,6 +28,10 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
     this.alignedProxyProgram = new Program(alignedAirdropsProgram, { connection: this.connection });
   }
 
+  public getAlignedDistributorProgramId(): PublicKey {
+    return this.alignedProxyProgram.programId;
+  }
+
   public async getAlignedDistributorData(distributorAddress: string): Promise<AlignedDistributorData> {
     const distributorKey = new PublicKey(distributorAddress);
     const alignedDistributorKey = getAlignedDistributorPda(this.alignedProxyProgram.programId, distributorKey);

--- a/packages/distributor/solana/constants.ts
+++ b/packages/distributor/solana/constants.ts
@@ -4,11 +4,20 @@ export const ANCHOR_DISCRIMINATOR_OFFSET = 8;
 export const DISTRIBUTOR_MINT_OFFSET = ANCHOR_DISCRIMINATOR_OFFSET + 41;
 export const DISTRIBUTOR_ADMIN_OFFSET = ANCHOR_DISCRIMINATOR_OFFSET + 201;
 
+export const DISTRIBUTOR_PREFIX = Buffer.from("MerkleDistributor", "utf-8");
 export const ALIGNED_DISTRIBUTOR_PREFIX = Buffer.from("aligned-distributor", "utf-8");
 export const TEST_ORACLE_PREFIX = Buffer.from("test-oracle", "utf-8");
+export const CLAIM_STATUS_PREFIX = Buffer.from("ClaimStatus", "utf-8");
 export const ALIGNED_PRECISION_FACTOR_POW = 9;
 
 export const ONE_IN_BASIS_POINTS = BigInt(10_000);
+
+export const ALIGNED_DISTRIBUTOR_PROGRAM_ID = {
+  [ICluster.Devnet]: "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
+  [ICluster.Mainnet]: "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
+  [ICluster.Testnet]: "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
+  [ICluster.Local]: "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
+};
 
 export const DISTRIBUTOR_PROGRAM_ID = {
   [ICluster.Devnet]: "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N",

--- a/packages/distributor/solana/utils.ts
+++ b/packages/distributor/solana/utils.ts
@@ -6,7 +6,13 @@ import { ContractError, divCeilN } from "@streamflow/common";
 import { ConfirmationParams, signAndExecuteTransaction, ThrottleParams } from "@streamflow/common/solana";
 
 import { fromTxError } from "./generated/errors/index.js";
-import { ONE_IN_BASIS_POINTS, ALIGNED_DISTRIBUTOR_PREFIX, TEST_ORACLE_PREFIX } from "./constants.js";
+import {
+  ONE_IN_BASIS_POINTS,
+  ALIGNED_DISTRIBUTOR_PREFIX,
+  TEST_ORACLE_PREFIX,
+  DISTRIBUTOR_PREFIX,
+  CLAIM_STATUS_PREFIX,
+} from "./constants.js";
 
 export const getAlignedDistributorPda = (programId: PublicKey, distributor: PublicKey): PublicKey => {
   return PublicKey.findProgramAddressSync([ALIGNED_DISTRIBUTOR_PREFIX, distributor.toBuffer()], programId)[0];
@@ -19,7 +25,7 @@ export const getTestOraclePda = (programId: PublicKey, mint: PublicKey, creator:
 export function getDistributorPda(programId: PublicKey, mint: PublicKey, version: number): PublicKey {
   // Constructing the seed for the PDA
   const seeds = [
-    Buffer.from("MerkleDistributor"),
+    DISTRIBUTOR_PREFIX,
     mint.toBuffer(),
     Buffer.from(new Uint8Array(new BigUint64Array([BigInt(version)]).buffer)),
   ];
@@ -30,7 +36,7 @@ export function getDistributorPda(programId: PublicKey, mint: PublicKey, version
 
 export function getClaimantStatusPda(programId: PublicKey, distributor: PublicKey, claimant: PublicKey): PublicKey {
   // Constructing the seed for the PDA
-  const seeds = [Buffer.from("ClaimStatus"), claimant.toBuffer(), distributor.toBuffer()];
+  const seeds = [CLAIM_STATUS_PREFIX, claimant.toBuffer(), distributor.toBuffer()];
 
   // Finding the PDA
   return PublicKey.findProgramAddressSync(seeds, programId)[0];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
Exposing some additional constants for Airdrops and `get` functions (programId, aligned proxy addres) for the Distributor clients