### PR TITLE
Configure Solana transactions scheduling 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.1.1",
+  "version": "7.2.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/common/solana/utils.ts
+++ b/packages/common/solana/utils.ts
@@ -39,8 +39,8 @@ import { sleep } from "../lib/utils.js";
 
 const SIMULATE_TRIES = 3;
 
-export const buildSendThrottler = (sendRate: number): PQueue => {
-  return new PQueue({ concurrency: sendRate, intervalCap: 1, interval: 1000 });
+export const buildSendThrottler = (sendRate: number, sendInterval = 1000): PQueue => {
+  return new PQueue({ concurrency: sendRate, intervalCap: 1, interval: sendInterval });
 };
 
 /**

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/stream/__tests__/common/GenericStreamClient.spec.ts
+++ b/packages/stream/__tests__/common/GenericStreamClient.spec.ts
@@ -2,14 +2,15 @@ import { Wallet } from "ethers";
 import { describe, expect, test } from "vitest";
 
 import { StreamflowAptos, StreamflowEVM, StreamflowSolana, StreamflowSui } from "../../index.js";
+import { default as GenericStreamClient } from "../../common/GenericStreamClient.js";
 import {
-  default as GenericStreamClient,
-  SolanaStreamClientOptions,
-  SuiStreamClientOptions,
   AptosStreamClientOptions,
   EvmStreamClientOptions,
-} from "../../common/GenericStreamClient.js";
-import { IChain, ICluster } from "../../common/types.js";
+  IChain,
+  ICluster,
+  SolanaStreamClientOptions,
+  SuiStreamClientOptions,
+} from "../../common/types.js";
 import { BaseStreamClient } from "../../common/BaseStreamClient.js";
 
 type StreamClientOptions =

--- a/packages/stream/common/GenericStreamClient.ts
+++ b/packages/stream/common/GenericStreamClient.ts
@@ -1,12 +1,7 @@
-import { Commitment, ConnectionConfig } from "@solana/web3.js";
-import { Signer } from "ethers";
-import PQueue from "p-queue";
-
 import { BaseStreamClient } from "./BaseStreamClient.js";
 import {
   ICancelData,
   IChain,
-  ICluster,
   ICreateMultipleStreamData,
   ICreateStreamData,
   IGetOneData,
@@ -21,6 +16,10 @@ import {
   Stream,
   IFees,
   IGetFeesData,
+  AptosStreamClientOptions,
+  SuiStreamClientOptions,
+  EvmStreamClientOptions,
+  SolanaStreamClientOptions,
 } from "./types.js";
 import { handleContractError } from "./utils.js";
 import { AptosStreamClient, ICreateStreamAptosExt, ITransactionAptosExt } from "../aptos/index.js";
@@ -31,41 +30,8 @@ import {
   IInteractStreamSolanaExt,
   ITopUpStreamSolanaExt,
 } from "../solana/index.js";
-import { ICreateStreamSuiExt, ITransactionSuiExt, ISuiIdParameters, SuiStreamClient } from "../sui/index.js";
+import { ICreateStreamSuiExt, ITransactionSuiExt, SuiStreamClient } from "../sui/index.js";
 import { WITHDRAW_AVAILABLE_AMOUNT } from "./constants.js";
-
-export interface SolanaStreamClientOptions {
-  chain: IChain.Solana;
-  clusterUrl: string;
-  cluster?: ICluster;
-  programId?: string;
-  commitment?: Commitment | ConnectionConfig;
-  sendRate?: number;
-  sendThrottler?: PQueue;
-}
-
-export interface AptosStreamClientOptions {
-  chain: IChain.Aptos;
-  clusterUrl: string;
-  cluster?: ICluster;
-  programId?: string;
-  maxGas?: string;
-}
-
-export interface EvmStreamClientOptions {
-  chain: IChain.Ethereum | IChain.BNB | IChain.Polygon;
-  clusterUrl: string;
-  signer: Signer;
-  cluster?: ICluster;
-  programId?: string;
-}
-
-export interface SuiStreamClientOptions {
-  chain: IChain.Sui;
-  clusterUrl: string;
-  cluster?: ICluster;
-  ids?: ISuiIdParameters;
-}
 
 /** Type referencing options for specific Chain Client */
 type StreamClientOptions<T extends IChain> = T extends IChain.Solana
@@ -129,14 +95,7 @@ export default class GenericStreamClient<T extends IChain> extends BaseStreamCli
 
     switch (options.chain) {
       case IChain.Solana:
-        this.nativeStreamClient = new SolanaStreamClient(
-          options.clusterUrl,
-          options.cluster,
-          options.commitment,
-          options.programId,
-          options.sendRate,
-          options.sendThrottler,
-        ) as StreamClientType<T>;
+        this.nativeStreamClient = new SolanaStreamClient(options) as StreamClientType<T>;
         break;
       case IChain.Aptos:
         this.nativeStreamClient = new AptosStreamClient(

--- a/packages/stream/common/types.ts
+++ b/packages/stream/common/types.ts
@@ -1,9 +1,14 @@
 import { Address } from "@coral-xyz/anchor";
-import { TransactionInstruction } from "@solana/web3.js";
+import { Commitment, ConnectionConfig, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { IChain, ICluster } from "@streamflow/common";
 import { Types } from "aptos";
 import BN from "bn.js";
+import type { Signer } from "ethers";
+import type { default as PQueue } from "p-queue";
 
-export { IChain, ICluster, ContractError } from "@streamflow/common";
+import { ISuiIdParameters } from "../sui/index.js";
+
+export { ContractError, IChain, ICluster } from "@streamflow/common";
 
 export interface IRecipient {
   recipient: string;
@@ -28,6 +33,7 @@ export interface IBaseStreamConfig {
   canPause?: boolean;
   canUpdateRate?: boolean;
   partner?: string;
+  tokenProgramId?: string | PublicKey;
 }
 
 export type IAlignedStreamConfig = {
@@ -332,4 +338,61 @@ export enum SolanaAlignedProxyErrorCode {
 
   /** All funds are already unlocked */
   AllFundsUnlocked = "AllFundsUnlocked",
+}
+
+/**
+ * @interface
+ */
+export interface SolanaStreamClientOptions {
+  chain: IChain.Solana;
+  clusterUrl: string;
+  cluster?: ICluster;
+  programId?: string;
+  commitment?: Commitment | ConnectionConfig;
+  sendRate?: number;
+  sendThrottler?: PQueue;
+  sendScheduler?:
+    | PQueue
+    | {
+        /**
+         * concurrency rate for scheduling
+         */
+        sendRate: number;
+        /**
+         * time interval between consecutive sends
+         */
+        sendInterval?: number;
+      };
+}
+
+/**
+ * @interface
+ */
+export interface AptosStreamClientOptions {
+  chain: IChain.Aptos;
+  clusterUrl: string;
+  cluster?: ICluster;
+  programId?: string;
+  maxGas?: string;
+}
+
+/**
+ * @interface
+ */
+export interface EvmStreamClientOptions {
+  chain: IChain.Ethereum | IChain.BNB | IChain.Polygon;
+  clusterUrl: string;
+  signer: Signer;
+  cluster?: ICluster;
+  programId?: string;
+}
+
+/**
+ * @interface
+ */
+export interface SuiStreamClientOptions {
+  chain: IChain.Sui;
+  clusterUrl: string;
+  cluster?: ICluster;
+  ids?: ISuiIdParameters;
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
to allow passing scheduling config along with a specific queue instance.

Extend throttle factory fn arguments: configure sending interval