### PR TITLE
Add support for claim limit for distributor

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/common/solana/public-key.ts
+++ b/packages/common/solana/public-key.ts
@@ -1,5 +1,10 @@
 import { PublicKey } from "@solana/web3.js";
 
+/**
+ * Converts a string or PublicKey to a PublicKey object.
+ * @param key - The input key as a string or PublicKey.
+ * @returns The PublicKey object.
+ */
 export const pk = (address: string | PublicKey): PublicKey => {
   return typeof address === "string" ? new PublicKey(address) : address;
 };

--- a/packages/common/solana/public-key.ts
+++ b/packages/common/solana/public-key.ts
@@ -2,7 +2,7 @@ import { PublicKey } from "@solana/web3.js";
 
 /**
  * Converts a string or PublicKey to a PublicKey object.
- * @param key - The input key as a string or PublicKey.
+ * @param address - The input address as a string or PublicKey.
  * @returns The PublicKey object.
  */
 export const pk = (address: string | PublicKey): PublicKey => {

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -19,6 +19,7 @@ import {
   buildSendThrottler,
   prepareWrappedAccount,
   IProgramAccount,
+  pk,
 } from "@streamflow/common/solana";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -325,7 +326,7 @@ export default abstract class BaseDistributorClient {
     const distributorPublicKey = new PublicKey(data.id);
     const distributor = await MerkleDistributor.fetch(this.connection, distributorPublicKey);
 
-    const claimantPublicKey = new PublicKey(data.claimant);
+    const claimantPublicKey = pk(data.claimant);
 
     if (!distributor) {
       throw new Error("Couldn't get distributor account info");
@@ -469,7 +470,7 @@ export default abstract class BaseDistributorClient {
       clawbackStartTs: new BN(data.clawbackStartTs),
       claimsClosableByAdmin: data.claimsClosableByAdmin,
       claimsClosableByClaimant: data.claimsClosableByClaimant,
-      claimsLimit: new BN(data.claimsLimit || 0),
+      claimsLimit: data.claimsLimit,
     };
 
     const nowTs = new BN(Math.floor(Date.now() / 1000));

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -41,6 +41,7 @@ import {
   ICreateDistributorData,
   ICreateAlignedDistributorData,
   ISearchDistributors,
+  ICloseClaimData,
 } from "../types";
 import {
   ClaimLockedAccounts,
@@ -60,6 +61,7 @@ import {
   getEventAuthorityPda,
   wrappedSignAndExecuteTransaction,
 } from "../utils";
+import { closeClaim, CloseClaimAccounts, CloseClaimArgs } from "../generated/instructions/closeClaim";
 
 export interface IInitOptions {
   clusterUrl: string;
@@ -294,6 +296,49 @@ export default abstract class BaseDistributorClient {
     return ixs;
   }
 
+  public async prepareCloseClaimInstructions(
+    data: ICloseClaimData,
+    extParams: IInteractSolanaExt,
+  ): Promise<TransactionInstruction[]> {
+    if (!extParams.invoker.publicKey) {
+      throw new Error("Invoker's PublicKey is not available, check passed wallet adapter!");
+    }
+
+    const distributorPublicKey = new PublicKey(data.id);
+    const distributor = await MerkleDistributor.fetch(this.connection, distributorPublicKey);
+
+    const claimantPublicKey = new PublicKey(data.claimant);
+
+    if (!distributor) {
+      throw new Error("Couldn't get distributor account info");
+    }
+
+    const ixs: TransactionInstruction[] = prepareBaseInstructions(this.connection, extParams);
+
+    const claimStatusPublicKey = getClaimantStatusPda(this.programId, distributorPublicKey, claimantPublicKey);
+    const eventAuthorityPublicKey = getEventAuthorityPda(this.programId);
+
+    const closeClaimAccounts: CloseClaimAccounts = {
+      adminOrClaimant: extParams.invoker.publicKey,
+      distributor: distributorPublicKey,
+      claimStatus: claimStatusPublicKey,
+      claimant: claimantPublicKey,
+      systemProgram: SystemProgram.programId,
+      eventAuthority: eventAuthorityPublicKey,
+      program: this.programId,
+    };
+
+    const closeClaimArgs: CloseClaimArgs = {
+      amountLocked: new BN(data.amountLocked),
+      amountUnlocked: new BN(data.amountUnlocked),
+      proof: data.proof,
+    };
+
+    ixs.push(closeClaim(closeClaimArgs, closeClaimAccounts, this.programId));
+
+    return ixs;
+  }
+
   public async prepareClawbackInstructions(
     data: IClawbackData,
     extParams: IInteractSolanaExt,
@@ -404,7 +449,9 @@ export default abstract class BaseDistributorClient {
       startVestingTs: new BN(data.startVestingTs),
       endVestingTs: new BN(data.endVestingTs),
       clawbackStartTs: new BN(data.clawbackStartTs),
-      claimsClosable: data.claimsClosable,
+      claimsClosableByAdmin: data.claimsClosableByAdmin,
+      claimsClosableByClaimant: data.claimsClosableByClaimant,
+      claimsLimit: new BN(data.claimsLimit || 0),
     };
 
     const nowTs = new BN(Math.floor(Date.now() / 1000));

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -296,6 +296,24 @@ export default abstract class BaseDistributorClient {
     return ixs;
   }
 
+  public async closeClaim(data: ICloseClaimData, extParams: IInteractSolanaExt): Promise<ITransactionResult> {
+    const ixs = await this.prepareCloseClaimInstructions(data, extParams);
+    const { tx, hash, context } = await prepareTransaction(this.connection, ixs, extParams.invoker.publicKey);
+    const signature = await wrappedSignAndExecuteTransaction(
+      this.connection,
+      extParams.invoker,
+      tx,
+      {
+        hash,
+        context,
+        commitment: this.getCommitment(),
+      },
+      { sendThrottler: this.sendThrottler },
+    );
+
+    return { ixs, txId: signature };
+  }
+
   public async prepareCloseClaimInstructions(
     data: ICloseClaimData,
     extParams: IInteractSolanaExt,

--- a/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
@@ -71,7 +71,15 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
 
     const newDistributorIx = await this.alignedProxyProgram.methods
       .newDistributor({
-        ...baseArgs,
+        claimsClosable: baseArgs.claimsClosableByAdmin,
+        version: baseArgs.version,
+        root: baseArgs.root,
+        maxTotalClaim: baseArgs.maxTotalClaim,
+        maxNumNodes: baseArgs.maxNumNodes,
+        unlockPeriod: baseArgs.unlockPeriod,
+        startVestingTs: baseArgs.startVestingTs,
+        endVestingTs: baseArgs.endVestingTs,
+        clawbackStartTs: baseArgs.clawbackStartTs,
         ...alignedArgs,
       })
       .accounts({

--- a/packages/distributor/solana/descriptor/aligned_distributor.ts
+++ b/packages/distributor/solana/descriptor/aligned_distributor.ts
@@ -8,7 +8,7 @@ export type AlignedDistributor = {
   address: "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2";
   metadata: {
     name: "alignedDistributor";
-    version: "1.2.0";
+    version: "1.3.0";
     spec: "0.1.0";
     description: "Proxy for merkle distributor that updates Vesting duration according to token market performance.";
   };
@@ -695,7 +695,7 @@ export type AlignedDistributor = {
             type: "bool";
           },
           {
-            name: "claimsClosable";
+            name: "claimsClosableByAdmin";
             docs: ["Whether claims are closable by the admin or not"];
             type: "bool";
           },
@@ -732,10 +732,20 @@ export type AlignedDistributor = {
             type: "u64";
           },
           {
+            name: "claimsClosableByClaimant";
+            docs: ["Whether claims are closable by claimant or not"];
+            type: "bool";
+          },
+          {
+            name: "claimsLimit";
+            docs: ["Limit number of claims"];
+            type: "u16";
+          },
+          {
             name: "buffer2";
             docs: ["Buffer for additional fields"];
             type: {
-              array: ["u8", 23];
+              array: ["u8", 20];
             };
           },
           {

--- a/packages/distributor/solana/descriptor/idl/aligned_distributor.json
+++ b/packages/distributor/solana/descriptor/idl/aligned_distributor.json
@@ -2,36 +2,23 @@
   "address": "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
   "metadata": {
     "name": "aligned_distributor",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "spec": "0.1.0",
     "description": "Proxy for merkle distributor that updates Vesting duration according to token market performance."
   },
   "instructions": [
     {
       "name": "change_oracle",
-      "discriminator": [
-        177,
-        227,
-        230,
-        103,
-        13,
-        72,
-        141,
-        248
-      ],
+      "discriminator": [177, 227, 230, 103, 13, 72, 141, 248],
       "accounts": [
         {
           "name": "aligned_distributor",
-          "docs": [
-            "The [MerkleDistributor]."
-          ],
+          "docs": ["The [MerkleDistributor]."],
           "writable": true
         },
         {
           "name": "admin",
-          "docs": [
-            "Admin signer"
-          ],
+          "docs": ["Admin signer"],
           "writable": true,
           "signer": true
         },
@@ -52,48 +39,17 @@
     },
     {
       "name": "clawback",
-      "discriminator": [
-        111,
-        92,
-        142,
-        79,
-        33,
-        234,
-        82,
-        27
-      ],
+      "discriminator": [111, 92, 142, 79, 33, 234, 82, 27],
       "accounts": [
         {
           "name": "aligned_distributor",
-          "docs": [
-            "The [AlignedDistributor]."
-          ],
+          "docs": ["The [AlignedDistributor]."],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  108,
-                  105,
-                  103,
-                  110,
-                  101,
-                  100,
-                  45,
-                  100,
-                  105,
-                  115,
-                  116,
-                  114,
-                  105,
-                  98,
-                  117,
-                  116,
-                  111,
-                  114
-                ]
+                "value": [97, 108, 105, 103, 110, 101, 100, 45, 100, 105, 115, 116, 114, 105, 98, 117, 116, 111, 114]
               },
               {
                 "kind": "account",
@@ -104,30 +60,22 @@
         },
         {
           "name": "distributor",
-          "docs": [
-            "The [MerkleDistributor]."
-          ],
+          "docs": ["The [MerkleDistributor]."],
           "writable": true
         },
         {
           "name": "from",
-          "docs": [
-            "Distributor ATA containing the tokens to distribute."
-          ],
+          "docs": ["Distributor ATA containing the tokens to distribute."],
           "writable": true
         },
         {
           "name": "to",
-          "docs": [
-            "The Clawback token account."
-          ],
+          "docs": ["The Clawback token account."],
           "writable": true
         },
         {
           "name": "admin",
-          "docs": [
-            "Only Admin can trigger the clawback of funds"
-          ],
+          "docs": ["Only Admin can trigger the clawback of funds"],
           "writable": true,
           "signer": true
         },
@@ -140,32 +88,19 @@
         },
         {
           "name": "system_program",
-          "docs": [
-            "The [System] program."
-          ],
+          "docs": ["The [System] program."],
           "address": "11111111111111111111111111111111"
         },
         {
           "name": "token_program",
-          "docs": [
-            "SPL [Token] program."
-          ]
+          "docs": ["SPL [Token] program."]
         }
       ],
       "args": []
     },
     {
       "name": "create_test_oracle",
-      "discriminator": [
-        183,
-        110,
-        4,
-        11,
-        131,
-        220,
-        84,
-        12
-      ],
+      "discriminator": [183, 110, 4, 11, 131, 220, 84, 12],
       "accounts": [
         {
           "name": "creator",
@@ -182,19 +117,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  116,
-                  101,
-                  115,
-                  116,
-                  45,
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [116, 101, 115, 116, 45, 111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -225,16 +148,7 @@
     },
     {
       "name": "new_distributor",
-      "discriminator": [
-        32,
-        139,
-        112,
-        171,
-        0,
-        2,
-        225,
-        155
-      ],
+      "discriminator": [32, 139, 112, 171, 0, 2, 225, 155],
       "accounts": [
         {
           "name": "aligned_distributor",
@@ -243,27 +157,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  108,
-                  105,
-                  103,
-                  110,
-                  101,
-                  100,
-                  45,
-                  100,
-                  105,
-                  115,
-                  116,
-                  114,
-                  105,
-                  98,
-                  117,
-                  116,
-                  111,
-                  114
-                ]
+                "value": [97, 108, 105, 103, 110, 101, 100, 45, 100, 105, 115, 116, 114, 105, 98, 117, 116, 111, 114]
               },
               {
                 "kind": "account",
@@ -282,16 +176,12 @@
         },
         {
           "name": "clawback_receiver",
-          "docs": [
-            "Clawback receiver token account"
-          ],
+          "docs": ["Clawback receiver token account"],
           "writable": true
         },
         {
           "name": "mint",
-          "docs": [
-            "The mint to distribute."
-          ]
+          "docs": ["The mint to distribute."]
         },
         {
           "name": "distributor",
@@ -312,30 +202,22 @@
         },
         {
           "name": "distributor_program",
-          "docs": [
-            "MerkleDistributor program"
-          ],
+          "docs": ["MerkleDistributor program"],
           "address": "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N"
         },
         {
           "name": "system_program",
-          "docs": [
-            "The [System] program."
-          ],
+          "docs": ["The [System] program."],
           "address": "11111111111111111111111111111111"
         },
         {
           "name": "associated_token_program",
-          "docs": [
-            "The [Associated Token] program."
-          ],
+          "docs": ["The [Associated Token] program."],
           "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         },
         {
           "name": "token_program",
-          "docs": [
-            "The [Token] program."
-          ]
+          "docs": ["The [Token] program."]
         }
       ],
       "args": [
@@ -351,37 +233,22 @@
     },
     {
       "name": "set_admin",
-      "discriminator": [
-        251,
-        163,
-        0,
-        52,
-        91,
-        194,
-        187,
-        92
-      ],
+      "discriminator": [251, 163, 0, 52, 91, 194, 187, 92],
       "accounts": [
         {
           "name": "aligned_distributor",
-          "docs": [
-            "The [MerkleDistributor]."
-          ],
+          "docs": ["The [MerkleDistributor]."],
           "writable": true
         },
         {
           "name": "admin",
-          "docs": [
-            "Admin signer"
-          ],
+          "docs": ["Admin signer"],
           "writable": true,
           "signer": true
         },
         {
           "name": "new_admin",
-          "docs": [
-            "New admin account"
-          ],
+          "docs": ["New admin account"],
           "writable": true
         }
       ],
@@ -389,16 +256,7 @@
     },
     {
       "name": "set_test_oracle_authority",
-      "discriminator": [
-        26,
-        66,
-        233,
-        99,
-        38,
-        118,
-        181,
-        247
-      ],
+      "discriminator": [26, 66, 233, 99, 38, 118, 181, 247],
       "accounts": [
         {
           "name": "authority",
@@ -417,56 +275,23 @@
     },
     {
       "name": "update_duration",
-      "discriminator": [
-        69,
-        126,
-        172,
-        250,
-        164,
-        14,
-        10,
-        161
-      ],
+      "discriminator": [69, 126, 172, 250, 164, 14, 10, 161],
       "accounts": [
         {
           "name": "authority",
-          "docs": [
-            "Wallet authorised to call this method"
-          ],
+          "docs": ["Wallet authorised to call this method"],
           "writable": true,
           "signer": true
         },
         {
           "name": "aligned_distributor",
-          "docs": [
-            "The account holding the proxy parameters."
-          ],
+          "docs": ["The account holding the proxy parameters."],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  97,
-                  108,
-                  105,
-                  103,
-                  110,
-                  101,
-                  100,
-                  45,
-                  100,
-                  105,
-                  115,
-                  116,
-                  114,
-                  105,
-                  98,
-                  117,
-                  116,
-                  111,
-                  114
-                ]
+                "value": [97, 108, 105, 103, 110, 101, 100, 45, 100, 105, 115, 116, 114, 105, 98, 117, 116, 111, 114]
               },
               {
                 "kind": "account",
@@ -477,22 +302,16 @@
         },
         {
           "name": "distributor",
-          "docs": [
-            "The account holding the vesting parameters."
-          ],
+          "docs": ["The account holding the vesting parameters."],
           "writable": true
         },
         {
           "name": "price_oracle",
-          "relations": [
-            "aligned_distributor"
-          ]
+          "relations": ["aligned_distributor"]
         },
         {
           "name": "distributor_program",
-          "docs": [
-            "MerkleDistributor program"
-          ],
+          "docs": ["MerkleDistributor program"],
           "address": "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N"
         },
         {
@@ -504,16 +323,7 @@
     },
     {
       "name": "update_test_oracle",
-      "discriminator": [
-        158,
-        147,
-        215,
-        74,
-        34,
-        123,
-        80,
-        76
-      ],
+      "discriminator": [158, 147, 215, 74, 34, 123, 80, 76],
       "accounts": [
         {
           "name": "authority",
@@ -540,42 +350,15 @@
   "accounts": [
     {
       "name": "AlignedDistributor",
-      "discriminator": [
-        128,
-        76,
-        80,
-        203,
-        248,
-        175,
-        3,
-        43
-      ]
+      "discriminator": [128, 76, 80, 203, 248, 175, 3, 43]
     },
     {
       "name": "MerkleDistributor",
-      "discriminator": [
-        77,
-        119,
-        139,
-        70,
-        84,
-        247,
-        12,
-        26
-      ]
+      "discriminator": [77, 119, 139, 70, 84, 247, 12, 26]
     },
     {
       "name": "TestOracle",
-      "discriminator": [
-        198,
-        49,
-        63,
-        134,
-        232,
-        251,
-        168,
-        28
-      ]
+      "discriminator": [198, 49, 63, 134, 232, 251, 168, 28]
     }
   ],
   "errors": [
@@ -653,38 +436,28 @@
   "types": [
     {
       "name": "AlignedDistributor",
-      "docs": [
-        "State for the account which distributes tokens."
-      ],
+      "docs": ["State for the account which distributes tokens."],
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "bump",
-            "docs": [
-              "Bump seed."
-            ],
+            "docs": ["Bump seed."],
             "type": "u8"
           },
           {
             "name": "distributor",
-            "docs": [
-              "[Mint] of the token to be distributed."
-            ],
+            "docs": ["[Mint] of the token to be distributed."],
             "type": "pubkey"
           },
           {
             "name": "admin",
-            "docs": [
-              "Admin wallet"
-            ],
+            "docs": ["Admin wallet"],
             "type": "pubkey"
           },
           {
             "name": "price_oracle_type",
-            "docs": [
-              "Type of the Oracle used to derive Token Price"
-            ],
+            "docs": ["Type of the Oracle used to derive Token Price"],
             "type": {
               "defined": {
                 "name": "OracleType"
@@ -693,65 +466,47 @@
           },
           {
             "name": "price_oracle",
-            "docs": [
-              "Address of the Price Oracle"
-            ],
+            "docs": ["Address of the Price Oracle"],
             "type": "pubkey"
           },
           {
             "name": "update_period",
-            "docs": [
-              "Period of updates, can be different from unlock period if needed"
-            ],
+            "docs": ["Period of updates, can be different from unlock period if needed"],
             "type": "u64"
           },
           {
             "name": "min_price",
-            "docs": [
-              "Min price boundary"
-            ],
+            "docs": ["Min price boundary"],
             "type": "u64"
           },
           {
             "name": "max_price",
-            "docs": [
-              "Max price boundary"
-            ],
+            "docs": ["Max price boundary"],
             "type": "u64"
           },
           {
             "name": "min_percentage",
-            "docs": [
-              "Min percentage boundary, can be 0 that equals 1 Raw Token"
-            ],
+            "docs": ["Min percentage boundary, can be 0 that equals 1 Raw Token"],
             "type": "u64"
           },
           {
             "name": "max_percentage",
-            "docs": [
-              "Max percentage boundary"
-            ],
+            "docs": ["Max percentage boundary"],
             "type": "u64"
           },
           {
             "name": "tick_size",
-            "docs": [
-              "Ticket size for percentage boundaries"
-            ],
+            "docs": ["Ticket size for percentage boundaries"],
             "type": "u64"
           },
           {
             "name": "start_ts",
-            "docs": [
-              "Copy start ts from the Distributor to be used in the worker"
-            ],
+            "docs": ["Copy start ts from the Distributor to be used in the worker"],
             "type": "u64"
           },
           {
             "name": "end_ts",
-            "docs": [
-              "Copy end ts from the Distributor to be used in the worker"
-            ],
+            "docs": ["Copy end ts from the Distributor to be used in the worker"],
             "type": "u64"
           },
           {
@@ -763,66 +518,43 @@
           },
           {
             "name": "last_price",
-            "docs": [
-              "Price used on last amount calculation"
-            ],
+            "docs": ["Price used on last amount calculation"],
             "type": "u64"
           },
           {
             "name": "initial_duration",
-            "docs": [
-              "Initial Airdrop Vesting duration"
-            ],
+            "docs": ["Initial Airdrop Vesting duration"],
             "type": "u64"
           },
           {
             "name": "initial_price",
-            "docs": [
-              "Initial token price at the time of Contract creation"
-            ],
+            "docs": ["Initial token price at the time of Contract creation"],
             "type": "u64"
           },
           {
             "name": "distributor_clawed_back",
-            "docs": [
-              "Whether distributor was clawed backed"
-            ],
+            "docs": ["Whether distributor was clawed backed"],
             "type": "bool"
           },
           {
             "name": "buffer_1",
-            "docs": [
-              "Buffer for additional fields"
-            ],
+            "docs": ["Buffer for additional fields"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
             "name": "buffer_2",
-            "docs": [
-              "Buffer for additional fields"
-            ],
+            "docs": ["Buffer for additional fields"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
             "name": "buffer_3",
-            "docs": [
-              "Buffer for additional fields"
-            ],
+            "docs": ["Buffer for additional fields"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           }
         ]
@@ -870,162 +602,115 @@
     },
     {
       "name": "MerkleDistributor",
-      "docs": [
-        "State for the account which distributes tokens."
-      ],
+      "docs": ["State for the account which distributes tokens."],
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "bump",
-            "docs": [
-              "Bump seed."
-            ],
+            "docs": ["Bump seed."],
             "type": "u8"
           },
           {
             "name": "version",
-            "docs": [
-              "Version of the airdrop"
-            ],
+            "docs": ["Version of the airdrop"],
             "type": "u64"
           },
           {
             "name": "root",
-            "docs": [
-              "The 256-bit merkle root."
-            ],
+            "docs": ["The 256-bit merkle root."],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
             "name": "mint",
-            "docs": [
-              "[Mint] of the token to be distributed."
-            ],
+            "docs": ["[Mint] of the token to be distributed."],
             "type": "pubkey"
           },
           {
             "name": "token_vault",
-            "docs": [
-              "Token Address of the vault"
-            ],
+            "docs": ["Token Address of the vault"],
             "type": "pubkey"
           },
           {
             "name": "max_total_claim",
-            "docs": [
-              "Maximum number of tokens that can ever be claimed from this [MerkleDistributor]."
-            ],
+            "docs": ["Maximum number of tokens that can ever be claimed from this [MerkleDistributor]."],
             "type": "u64"
           },
           {
             "name": "max_num_nodes",
-            "docs": [
-              "Maximum number of nodes in [MerkleDistributor]."
-            ],
+            "docs": ["Maximum number of nodes in [MerkleDistributor]."],
             "type": "u64"
           },
           {
             "name": "unlock_period",
-            "docs": [
-              "Time step (period) in seconds per which the unlock occurs"
-            ],
+            "docs": ["Time step (period) in seconds per which the unlock occurs"],
             "type": "u64"
           },
           {
             "name": "total_amount_claimed",
-            "docs": [
-              "Total amount of tokens that have been claimed."
-            ],
+            "docs": ["Total amount of tokens that have been claimed."],
             "type": "u64"
           },
           {
             "name": "num_nodes_claimed",
-            "docs": [
-              "Number of nodes that have been claimed."
-            ],
+            "docs": ["Number of nodes that have been claimed."],
             "type": "u64"
           },
           {
             "name": "start_ts",
-            "docs": [
-              "Lockup time start (Unix Timestamp)"
-            ],
+            "docs": ["Lockup time start (Unix Timestamp)"],
             "type": "u64"
           },
           {
             "name": "end_ts",
-            "docs": [
-              "Lockup time end (Unix Timestamp)"
-            ],
+            "docs": ["Lockup time end (Unix Timestamp)"],
             "type": "u64"
           },
           {
             "name": "clawback_start_ts",
-            "docs": [
-              "Clawback start (Unix Timestamp)"
-            ],
+            "docs": ["Clawback start (Unix Timestamp)"],
             "type": "u64"
           },
           {
             "name": "clawback_receiver",
-            "docs": [
-              "Clawback receiver"
-            ],
+            "docs": ["Clawback receiver"],
             "type": "pubkey"
           },
           {
             "name": "admin",
-            "docs": [
-              "Admin wallet"
-            ],
+            "docs": ["Admin wallet"],
             "type": "pubkey"
           },
           {
             "name": "clawed_back",
-            "docs": [
-              "Whether or not the distributor has been clawed back"
-            ],
+            "docs": ["Whether or not the distributor has been clawed back"],
             "type": "bool"
           },
           {
-            "name": "claims_closable",
-            "docs": [
-              "Whether claims are closable by the admin or not"
-            ],
+            "name": "claims_closable_by_admin",
+            "docs": ["Whether claims are closable by the admin or not"],
             "type": "bool"
           },
           {
             "name": "can_update_duration",
-            "docs": [
-              "Whether admin can update vesting duration"
-            ],
+            "docs": ["Whether admin can update vesting duration"],
             "type": "bool"
           },
           {
             "name": "total_amount_unlocked",
-            "docs": [
-              "Total amount of funds unlocked (cliff/instant)"
-            ],
+            "docs": ["Total amount of funds unlocked (cliff/instant)"],
             "type": "u64"
           },
           {
             "name": "total_amount_locked",
-            "docs": [
-              "Total amount of funds locked (vested)"
-            ],
+            "docs": ["Total amount of funds locked (vested)"],
             "type": "u64"
           },
           {
             "name": "last_duration_update_ts",
-            "docs": [
-              "Timestamp when update was last called"
-            ],
+            "docs": ["Timestamp when update was last called"],
             "type": "u64"
           },
           {
@@ -1037,33 +722,31 @@
           },
           {
             "name": "clawed_back_ts",
-            "docs": [
-              "Timestamp when funds were clawed back"
-            ],
+            "docs": ["Timestamp when funds were clawed back"],
             "type": "u64"
           },
           {
+            "name": "claims_closable_by_claimant",
+            "docs": ["Whether claims are closable by claimant or not"],
+            "type": "bool"
+          },
+          {
+            "name": "claims_limit",
+            "docs": ["Limit number of claims"],
+            "type": "u16"
+          },
+          {
             "name": "buffer_2",
-            "docs": [
-              "Buffer for additional fields"
-            ],
+            "docs": ["Buffer for additional fields"],
             "type": {
-              "array": [
-                "u8",
-                23
-              ]
+              "array": ["u8", 20]
             }
           },
           {
             "name": "buffer_3",
-            "docs": [
-              "Buffer for additional fields"
-            ],
+            "docs": ["Buffer for additional fields"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           }
         ]
@@ -1081,10 +764,7 @@
           {
             "name": "root",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {

--- a/packages/distributor/solana/generated/accounts/ClaimStatus.ts
+++ b/packages/distributor/solana/generated/accounts/ClaimStatus.ts
@@ -21,6 +21,10 @@ export interface ClaimStatusFields {
   closed: boolean;
   /** Distributor account for which ClaimStatus was created, useful to filter by in get_program_accounts */
   distributor: PublicKey;
+  /** Number of time amount has been claimed */
+  claimsCount: BN;
+  /** Time when claim was closed */
+  closedTs: BN;
   /** Buffer for additional fields */
   buffer2: Array<number>;
 }
@@ -42,6 +46,10 @@ export interface ClaimStatusJSON {
   closed: boolean;
   /** Distributor account for which ClaimStatus was created, useful to filter by in get_program_accounts */
   distributor: string;
+  /** Number of time amount has been claimed */
+  claimsCount: string;
+  /** Time when claim was closed */
+  closedTs: string;
   /** Buffer for additional fields */
   buffer2: Array<number>;
 }
@@ -72,6 +80,12 @@ export class ClaimStatus {
   /** Distributor account for which ClaimStatus was created, useful to filter by in get_program_accounts */
   readonly distributor: PublicKey;
 
+  /** Number of time amount has been claimed */
+  readonly claimsCount: BN;
+
+  /** Time when claim was closed */
+  readonly closedTs: BN;
+
   /** Buffer for additional fields */
   readonly buffer2: Array<number>;
 
@@ -86,7 +100,9 @@ export class ClaimStatus {
     borsh.u64("lastAmountPerUnlock"),
     borsh.bool("closed"),
     borsh.publicKey("distributor"),
-    borsh.array(borsh.u8(), 32, "buffer2"),
+    borsh.u16("claimsCount"),
+    borsh.u64("closedTs"),
+    borsh.array(borsh.u8(), 22, "buffer2"),
   ]);
 
   constructor(fields: ClaimStatusFields) {
@@ -98,6 +114,8 @@ export class ClaimStatus {
     this.lastAmountPerUnlock = fields.lastAmountPerUnlock;
     this.closed = fields.closed;
     this.distributor = fields.distributor;
+    this.claimsCount = fields.claimsCount;
+    this.closedTs = fields.closedTs;
     this.buffer2 = fields.buffer2;
   }
 
@@ -153,6 +171,8 @@ export class ClaimStatus {
       lastAmountPerUnlock: dec.lastAmountPerUnlock,
       closed: dec.closed,
       distributor: dec.distributor,
+      claimsCount: dec.claimsCount,
+      closedTs: dec.closedTs,
       buffer2: dec.buffer2,
     });
   }
@@ -167,6 +187,8 @@ export class ClaimStatus {
       lastAmountPerUnlock: this.lastAmountPerUnlock.toString(),
       closed: this.closed,
       distributor: this.distributor.toString(),
+      claimsCount: this.claimsCount.toString(),
+      closedTs: this.closedTs.toString(),
       buffer2: this.buffer2,
     };
   }
@@ -181,6 +203,8 @@ export class ClaimStatus {
       lastAmountPerUnlock: new BN(obj.lastAmountPerUnlock),
       closed: obj.closed,
       distributor: new PublicKey(obj.distributor),
+      claimsCount: new BN(obj.claimsCount),
+      closedTs: new BN(obj.closedTs),
       buffer2: obj.buffer2,
     });
   }

--- a/packages/distributor/solana/generated/accounts/ClaimStatus.ts
+++ b/packages/distributor/solana/generated/accounts/ClaimStatus.ts
@@ -22,7 +22,7 @@ export interface ClaimStatusFields {
   /** Distributor account for which ClaimStatus was created, useful to filter by in get_program_accounts */
   distributor: PublicKey;
   /** Number of time amount has been claimed */
-  claimsCount: BN;
+  claimsCount: number;
   /** Time when claim was closed */
   closedTs: BN;
   /** Buffer for additional fields */
@@ -47,7 +47,7 @@ export interface ClaimStatusJSON {
   /** Distributor account for which ClaimStatus was created, useful to filter by in get_program_accounts */
   distributor: string;
   /** Number of time amount has been claimed */
-  claimsCount: string;
+  claimsCount: number;
   /** Time when claim was closed */
   closedTs: string;
   /** Buffer for additional fields */
@@ -81,7 +81,7 @@ export class ClaimStatus {
   readonly distributor: PublicKey;
 
   /** Number of time amount has been claimed */
-  readonly claimsCount: BN;
+  readonly claimsCount: number;
 
   /** Time when claim was closed */
   readonly closedTs: BN;
@@ -187,7 +187,7 @@ export class ClaimStatus {
       lastAmountPerUnlock: this.lastAmountPerUnlock.toString(),
       closed: this.closed,
       distributor: this.distributor.toString(),
-      claimsCount: this.claimsCount.toString(),
+      claimsCount: this.claimsCount,
       closedTs: this.closedTs.toString(),
       buffer2: this.buffer2,
     };
@@ -203,7 +203,7 @@ export class ClaimStatus {
       lastAmountPerUnlock: new BN(obj.lastAmountPerUnlock),
       closed: obj.closed,
       distributor: new PublicKey(obj.distributor),
-      claimsCount: new BN(obj.claimsCount),
+      claimsCount: obj.claimsCount,
       closedTs: new BN(obj.closedTs),
       buffer2: obj.buffer2,
     });

--- a/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
+++ b/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
@@ -54,7 +54,7 @@ export interface MerkleDistributorFields {
   /** Whether claims are closable by the claimant or not */
   claimsClosableByClaimant: boolean;
   /** Limit number of claims */
-  claimsLimit: BN;
+  claimsLimit: number;
   /** Buffer for additional fields */
   buffer2: Array<number>;
   /** Buffer for additional fields */
@@ -111,7 +111,7 @@ export interface MerkleDistributorJSON {
   /** Whether claims are closable by the claimant or not */
   claimsClosableByClaimant: boolean;
   /** Limit number of claims */
-  claimsLimit: string;
+  claimsLimit: number;
   /** Buffer for additional fields */
   buffer2: Array<number>;
   /** Buffer for additional fields */
@@ -193,7 +193,7 @@ export class MerkleDistributor {
   readonly claimsClosableByClaimant: boolean;
 
   /** Limit number of claims */
-  readonly claimsLimit: BN;
+  readonly claimsLimit: number;
 
   /** Buffer for additional fields */
   readonly buffer2: Array<number>;
@@ -363,7 +363,7 @@ export class MerkleDistributor {
       totalClaimablePreUpdate: this.totalClaimablePreUpdate.toString(),
       clawedBackTs: this.clawedBackTs.toString(),
       claimsClosableByClaimant: this.claimsClosableByClaimant,
-      claimsLimit: this.claimsLimit.toString(),
+      claimsLimit: this.claimsLimit,
       buffer2: this.buffer2,
       buffer3: this.buffer3,
     };
@@ -395,7 +395,7 @@ export class MerkleDistributor {
       totalClaimablePreUpdate: new BN(obj.totalClaimablePreUpdate),
       clawedBackTs: new BN(obj.clawedBackTs),
       claimsClosableByClaimant: obj.claimsClosableByClaimant,
-      claimsLimit: new BN(obj.claimsLimit),
+      claimsLimit: obj.claimsLimit,
       buffer2: obj.buffer2,
       buffer3: obj.buffer3,
     });

--- a/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
+++ b/packages/distributor/solana/generated/accounts/MerkleDistributor.ts
@@ -38,7 +38,7 @@ export interface MerkleDistributorFields {
   /** Whether or not the distributor has been clawed back */
   clawedBack: boolean;
   /** Whether claims are closable by the admin or not */
-  claimsClosable: boolean;
+  claimsClosableByAdmin: boolean;
   /** Whether admin can update vesting duration */
   canUpdateDuration: boolean;
   /** Total amount of funds unlocked (cliff/instant) */
@@ -51,6 +51,10 @@ export interface MerkleDistributorFields {
   totalClaimablePreUpdate: BN;
   /** Timestamp when funds were clawed back */
   clawedBackTs: BN;
+  /** Whether claims are closable by the claimant or not */
+  claimsClosableByClaimant: boolean;
+  /** Limit number of claims */
+  claimsLimit: BN;
   /** Buffer for additional fields */
   buffer2: Array<number>;
   /** Buffer for additional fields */
@@ -91,7 +95,7 @@ export interface MerkleDistributorJSON {
   /** Whether or not the distributor has been clawed back */
   clawedBack: boolean;
   /** Whether claims are closable by the admin or not */
-  claimsClosable: boolean;
+  claimsClosableByAdmin: boolean;
   /** Whether admin can update vesting duration */
   canUpdateDuration: boolean;
   /** Total amount of funds unlocked (cliff/instant) */
@@ -104,6 +108,10 @@ export interface MerkleDistributorJSON {
   totalClaimablePreUpdate: string;
   /** Timestamp when funds were clawed back */
   clawedBackTs: string;
+  /** Whether claims are closable by the claimant or not */
+  claimsClosableByClaimant: boolean;
+  /** Limit number of claims */
+  claimsLimit: string;
   /** Buffer for additional fields */
   buffer2: Array<number>;
   /** Buffer for additional fields */
@@ -161,7 +169,7 @@ export class MerkleDistributor {
   readonly clawedBack: boolean;
 
   /** Whether claims are closable by the admin or not */
-  readonly claimsClosable: boolean;
+  readonly claimsClosableByAdmin: boolean;
 
   /** Whether admin can update vesting duration */
   readonly canUpdateDuration: boolean;
@@ -180,6 +188,12 @@ export class MerkleDistributor {
 
   /** Timestamp when funds were clawed back */
   readonly clawedBackTs: BN;
+
+  /** Whether claims are closable by the claimant or not */
+  readonly claimsClosableByClaimant: boolean;
+
+  /** Limit number of claims */
+  readonly claimsLimit: BN;
 
   /** Buffer for additional fields */
   readonly buffer2: Array<number>;
@@ -206,14 +220,16 @@ export class MerkleDistributor {
     borsh.publicKey("clawbackReceiver"),
     borsh.publicKey("admin"),
     borsh.bool("clawedBack"),
-    borsh.bool("claimsClosable"),
+    borsh.bool("claimsClosableByAdmin"),
     borsh.bool("canUpdateDuration"),
     borsh.u64("totalAmountUnlocked"),
     borsh.u64("totalAmountLocked"),
     borsh.u64("lastDurationUpdateTs"),
     borsh.u64("totalClaimablePreUpdate"),
     borsh.u64("clawedBackTs"),
-    borsh.array(borsh.u8(), 23, "buffer2"),
+    borsh.bool("claimsClosableByClaimant"),
+    borsh.u16("claimsLimit"),
+    borsh.array(borsh.u8(), 20, "buffer2"),
     borsh.array(borsh.u8(), 32, "buffer3"),
   ]);
 
@@ -234,13 +250,15 @@ export class MerkleDistributor {
     this.clawbackReceiver = fields.clawbackReceiver;
     this.admin = fields.admin;
     this.clawedBack = fields.clawedBack;
-    this.claimsClosable = fields.claimsClosable;
+    this.claimsClosableByAdmin = fields.claimsClosableByAdmin;
     this.canUpdateDuration = fields.canUpdateDuration;
     this.totalAmountUnlocked = fields.totalAmountUnlocked;
     this.totalAmountLocked = fields.totalAmountLocked;
     this.lastDurationUpdateTs = fields.lastDurationUpdateTs;
     this.totalClaimablePreUpdate = fields.totalClaimablePreUpdate;
     this.clawedBackTs = fields.clawedBackTs;
+    this.claimsClosableByClaimant = fields.claimsClosableByClaimant;
+    this.claimsLimit = fields.claimsLimit;
     this.buffer2 = fields.buffer2;
     this.buffer3 = fields.buffer3;
   }
@@ -305,13 +323,15 @@ export class MerkleDistributor {
       clawbackReceiver: dec.clawbackReceiver,
       admin: dec.admin,
       clawedBack: dec.clawedBack,
-      claimsClosable: dec.claimsClosable,
+      claimsClosableByAdmin: dec.claimsClosableByAdmin,
       canUpdateDuration: dec.canUpdateDuration,
       totalAmountUnlocked: dec.totalAmountUnlocked,
       totalAmountLocked: dec.totalAmountLocked,
       lastDurationUpdateTs: dec.lastDurationUpdateTs,
       totalClaimablePreUpdate: dec.totalClaimablePreUpdate,
       clawedBackTs: dec.clawedBackTs,
+      claimsClosableByClaimant: dec.claimsClosableByClaimant,
+      claimsLimit: dec.claimsLimit,
       buffer2: dec.buffer2,
       buffer3: dec.buffer3,
     });
@@ -335,13 +355,15 @@ export class MerkleDistributor {
       clawbackReceiver: this.clawbackReceiver.toString(),
       admin: this.admin.toString(),
       clawedBack: this.clawedBack,
-      claimsClosable: this.claimsClosable,
+      claimsClosableByAdmin: this.claimsClosableByAdmin,
       canUpdateDuration: this.canUpdateDuration,
       totalAmountUnlocked: this.totalAmountUnlocked.toString(),
       totalAmountLocked: this.totalAmountLocked.toString(),
       lastDurationUpdateTs: this.lastDurationUpdateTs.toString(),
       totalClaimablePreUpdate: this.totalClaimablePreUpdate.toString(),
       clawedBackTs: this.clawedBackTs.toString(),
+      claimsClosableByClaimant: this.claimsClosableByClaimant,
+      claimsLimit: this.claimsLimit.toString(),
       buffer2: this.buffer2,
       buffer3: this.buffer3,
     };
@@ -365,13 +387,15 @@ export class MerkleDistributor {
       clawbackReceiver: new PublicKey(obj.clawbackReceiver),
       admin: new PublicKey(obj.admin),
       clawedBack: obj.clawedBack,
-      claimsClosable: obj.claimsClosable,
+      claimsClosableByAdmin: obj.claimsClosableByAdmin,
       canUpdateDuration: obj.canUpdateDuration,
       totalAmountUnlocked: new BN(obj.totalAmountUnlocked),
       totalAmountLocked: new BN(obj.totalAmountLocked),
       lastDurationUpdateTs: new BN(obj.lastDurationUpdateTs),
       totalClaimablePreUpdate: new BN(obj.totalClaimablePreUpdate),
       clawedBackTs: new BN(obj.clawedBackTs),
+      claimsClosableByClaimant: obj.claimsClosableByClaimant,
+      claimsLimit: new BN(obj.claimsLimit),
       buffer2: obj.buffer2,
       buffer3: obj.buffer3,
     });

--- a/packages/distributor/solana/generated/errors/custom.ts
+++ b/packages/distributor/solana/generated/errors/custom.ts
@@ -17,7 +17,12 @@ export type CustomError =
   | InvalidMint
   | ClaimIsClosed
   | ClaimsAreNotClosable
-  | InvalidUnlockPeriod;
+  | InvalidUnlockPeriod
+  | DurationUpdateNotAllowed
+  | NoVestingAmount
+  | VestingAlreadyFinished
+  | InvalidAmounts
+  | ClaimsLimitReached;
 
 export class InsufficientUnlockedTokens extends Error {
   static readonly code = 6000;
@@ -285,6 +290,76 @@ export class InvalidUnlockPeriod extends Error {
   }
 }
 
+export class DurationUpdateNotAllowed extends Error {
+  static readonly code = 6019;
+
+  readonly code = 6019;
+
+  readonly name = "DurationUpdateNotAllowed";
+
+  readonly msg = "Duration update is not allowed";
+
+  constructor(readonly logs?: string[]) {
+    super("6019: Duration update is not allowed");
+  }
+}
+
+export class NoVestingAmount extends Error {
+  static readonly code = 6020;
+
+  readonly code = 6020;
+
+  readonly name = "NoVestingAmount";
+
+  readonly msg = "Vesting amounts are not set";
+
+  constructor(readonly logs?: string[]) {
+    super("6020: Vesting amounts are not set");
+  }
+}
+
+export class VestingAlreadyFinished extends Error {
+  static readonly code = 6021;
+
+  readonly code = 6021;
+
+  readonly name = "VestingAlreadyFinished";
+
+  readonly msg = "Vesting already finished";
+
+  constructor(readonly logs?: string[]) {
+    super("6021: Vesting already finished");
+  }
+}
+
+export class InvalidAmounts extends Error {
+  static readonly code = 6022;
+
+  readonly code = 6022;
+
+  readonly name = "InvalidAmounts";
+
+  readonly msg = "Provided amounts are invalid";
+
+  constructor(readonly logs?: string[]) {
+    super("6022: Provided amounts are invalid");
+  }
+}
+
+export class ClaimsLimitReached extends Error {
+  static readonly code = 6023;
+
+  readonly code = 6023;
+
+  readonly name = "ClaimsLimitReached";
+
+  readonly msg = "Claims limit has been reached";
+
+  constructor(readonly logs?: string[]) {
+    super("6023: Claims limit has been reached");
+  }
+}
+
 export function fromCode(code: number, logs?: string[]): CustomError | null {
   switch (code) {
     case 6000:
@@ -325,6 +400,16 @@ export function fromCode(code: number, logs?: string[]): CustomError | null {
       return new ClaimsAreNotClosable(logs);
     case 6018:
       return new InvalidUnlockPeriod(logs);
+    case 6019:
+      return new DurationUpdateNotAllowed(logs);
+    case 6020:
+      return new NoVestingAmount(logs);
+    case 6021:
+      return new VestingAlreadyFinished(logs);
+    case 6022:
+      return new InvalidAmounts(logs);
+    case 6023:
+      return new ClaimsLimitReached(logs);
   }
 
   return null;

--- a/packages/distributor/solana/generated/instructions/closeClaim.ts
+++ b/packages/distributor/solana/generated/instructions/closeClaim.ts
@@ -5,11 +5,16 @@ import { Buffer } from "buffer";
 
 import { PROGRAM_ID } from "../programId";
 
+export interface CloseClaimArgs {
+  amountUnlocked: BN;
+  amountLocked: BN;
+  proof: Array<Array<number>>;
+}
 export interface CloseClaimAccounts {
   /** The [MerkleDistributor]. */
   distributor: PublicKey;
   /** Admin signer */
-  admin: PublicKey;
+  adminOrClaimant: PublicKey;
   claimant: PublicKey;
   /** Claim Status PDA */
   claimStatus: PublicKey;
@@ -19,10 +24,16 @@ export interface CloseClaimAccounts {
   program: PublicKey;
 }
 
-export function closeClaim(accounts: CloseClaimAccounts, programId: PublicKey = PROGRAM_ID) {
+export const layout = borsh.struct([
+  borsh.u64("amountUnlocked"),
+  borsh.u64("amountLocked"),
+  borsh.vec(borsh.array(borsh.u8(), 32), "proof"),
+]);
+
+export function closeClaim(args: CloseClaimArgs, accounts: CloseClaimAccounts, programId: PublicKey = PROGRAM_ID) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.distributor, isSigner: false, isWritable: true },
-    { pubkey: accounts.admin, isSigner: true, isWritable: true },
+    { pubkey: accounts.adminOrClaimant, isSigner: true, isWritable: true },
     { pubkey: accounts.claimant, isSigner: false, isWritable: false },
     { pubkey: accounts.claimStatus, isSigner: false, isWritable: true },
     { pubkey: accounts.systemProgram, isSigner: false, isWritable: false },
@@ -30,7 +41,16 @@ export function closeClaim(accounts: CloseClaimAccounts, programId: PublicKey = 
     { pubkey: accounts.program, isSigner: false, isWritable: false },
   ];
   const identifier = Buffer.from([42, 177, 165, 35, 213, 179, 211, 19]);
-  const data = identifier;
+  const buffer = Buffer.alloc(1000);
+  const len = layout.encode(
+    {
+      amountUnlocked: args.amountUnlocked,
+      amountLocked: args.amountLocked,
+      proof: args.proof,
+    },
+    buffer,
+  );
+  const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len);
   const ix = new TransactionInstruction({ keys, programId, data });
   return ix;
 }

--- a/packages/distributor/solana/generated/instructions/closeClaim.ts
+++ b/packages/distributor/solana/generated/instructions/closeClaim.ts
@@ -6,9 +6,9 @@ import { Buffer } from "buffer";
 import { PROGRAM_ID } from "../programId";
 
 export interface CloseClaimArgs {
-  amountUnlocked: BN;
-  amountLocked: BN;
-  proof: Array<Array<number>>;
+  amountUnlocked?: BN;
+  amountLocked?: BN;
+  proof?: Array<Array<number>>;
 }
 export interface CloseClaimAccounts {
   /** The [MerkleDistributor]. */
@@ -25,9 +25,9 @@ export interface CloseClaimAccounts {
 }
 
 export const layout = borsh.struct([
-  borsh.u64("amountUnlocked"),
-  borsh.u64("amountLocked"),
-  borsh.vec(borsh.array(borsh.u8(), 32), "proof"),
+  borsh.option(borsh.u64(), "amountUnlocked"),
+  borsh.option(borsh.u64(), "amountLocked"),
+  borsh.option(borsh.vec(borsh.array(borsh.u8(), 32)), "proof"),
 ]);
 
 export function closeClaim(args: CloseClaimArgs, accounts: CloseClaimAccounts, programId: PublicKey = PROGRAM_ID) {

--- a/packages/distributor/solana/generated/instructions/newDistributor.ts
+++ b/packages/distributor/solana/generated/instructions/newDistributor.ts
@@ -15,8 +15,8 @@ export interface NewDistributorArgs {
   endVestingTs: BN;
   clawbackStartTs: BN;
   claimsClosableByAdmin: boolean;
-  claimsClosableByClaimant: boolean;
-  claimsLimit: BN;
+  claimsClosableByClaimant?: boolean;
+  claimsLimit?: number;
 }
 
 export interface NewDistributorAccounts {

--- a/packages/distributor/solana/generated/instructions/newDistributor.ts
+++ b/packages/distributor/solana/generated/instructions/newDistributor.ts
@@ -14,7 +14,9 @@ export interface NewDistributorArgs {
   startVestingTs: BN;
   endVestingTs: BN;
   clawbackStartTs: BN;
-  claimsClosable: boolean;
+  claimsClosableByAdmin: boolean;
+  claimsClosableByClaimant: boolean;
+  claimsLimit: BN;
 }
 
 export interface NewDistributorAccounts {
@@ -107,12 +109,12 @@ export function newDistributor(
       startVestingTs: args.startVestingTs,
       endVestingTs: args.endVestingTs,
       clawbackStartTs: args.clawbackStartTs,
-      claimsClosableByAdmin: args.claimsClosable,
+      claimsClosableByAdmin: args.claimsClosableByAdmin,
       canUpdateDuration: null,
       totalAmountUnlocked: null,
       totalAmountLocked: null,
-      claimsClosableByClaimant: null,
-      claimsLimit: null,
+      claimsClosableByClaimant: args.claimsClosableByClaimant,
+      claimsLimit: args.claimsLimit,
     },
     buffer,
   );

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -1,5 +1,5 @@
 import { SignerWalletAdapter } from "@solana/wallet-adapter-base";
-import { Keypair } from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import { ITransactionResult } from "@streamflow/common";
 import { ITransactionSolanaExt } from "@streamflow/common/solana";
 import BN from "bn.js";
@@ -29,7 +29,9 @@ export interface ICreateDistributorData {
   startVestingTs: number;
   endVestingTs: number;
   clawbackStartTs: number;
-  claimsClosable: boolean;
+  claimsClosableByAdmin: boolean;
+  claimsClosableByClaimant: boolean;
+  claimsLimit?: number;
 }
 
 export interface AlignedDistributorData {
@@ -77,6 +79,10 @@ export interface IClaimData {
   amountUnlocked: BN;
   amountLocked: BN;
   proof: Array<Array<number>>;
+}
+
+export interface ICloseClaimData extends IClaimData {
+  claimant: string | PublicKey;
 }
 
 export interface IClawbackData {

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -30,7 +30,7 @@ export interface ICreateDistributorData {
   endVestingTs: number;
   clawbackStartTs: number;
   claimsClosableByAdmin: boolean;
-  claimsClosableByClaimant: boolean;
+  claimsClosableByClaimant?: boolean;
   claimsLimit?: number;
 }
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
Exposes the `claimsLimit` argument for distributor creation as well as the `closeClaim` method. 

[Protocol PR](https://github.com/streamflow-finance/distributor/pull/9) 