### PR TITLE
Add support for determining dynamic lock type

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.4.11",
+  "version": "7.4.12",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/stream/solana/types.ts
+++ b/packages/stream/solana/types.ts
@@ -247,6 +247,9 @@ export class AlignedContract extends Contract implements AlignedStream {
     this.sender = alignedProxy.sender.toBase58();
     this.canceledAt = alignedProxy.streamCanceledTime.toNumber();
     this.proxyAddress = stream.sender.toBase58();
+    // need to call this again since minPrice and maxPrice are used in determining the type
+    this.type = buildStreamType(this);
+    this.isAligned = true;
   }
 }
 


### PR DESCRIPTION
We are creating contracts under "Locks" that have different criteria for determining correct `StreamType`

`maxPrice - minPrice` will always be  <= 1 for these contracts. There is a possible edge case for wrong categorization if `maxPrice` is equal to or less than the minimum token denominator (in that case `minPrice` might be <=0 and we would fit this into vesting)