### PR TITLE
Add batching for getMultipleAccountsInfo

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.4.15",
+  "version": "7.4.16",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "license": "ISC",
   "main": "index.js",
   "files": [

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "dist/esm/index.js",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "7.4.15",
+  "version": "7.4.16",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/esm/index.js",

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -33,6 +33,7 @@ import {
   buildSendThrottler,
   IProgramAccount,
   ThrottleParams,
+  getMultipleAccountsInfoBatched,
 } from "@streamflow/common/solana";
 import * as borsh from "borsh";
 import { Program } from "@coral-xyz/anchor";
@@ -1360,7 +1361,7 @@ export class SolanaStreamClient extends BaseStreamClient {
       },
     ]);
     const streamPubKeys = alignedOutgoingProgramAccounts.map((account) => account.account.stream);
-    const streamAccounts = await this.connection.getMultipleAccountsInfo(streamPubKeys, TX_FINALITY_CONFIRMED);
+    const streamAccounts = await getMultipleAccountsInfoBatched(this.connection, streamPubKeys, TX_FINALITY_CONFIRMED);
     streamAccounts.forEach((account, index) => {
       if (account) {
         const alignedData = alignedOutgoingProgramAccounts[index].account;
@@ -1379,7 +1380,7 @@ export class SolanaStreamClient extends BaseStreamClient {
     const alignedProxyPDAs = alignedStreamsPubKeys.map((streamPubKey) =>
       deriveContractPDA(this.alignedProxyProgram.programId, new PublicKey(streamPubKey)),
     );
-    const alignedProxyAccounts = await this.connection.getMultipleAccountsInfo(alignedProxyPDAs);
+    const alignedProxyAccounts = await getMultipleAccountsInfoBatched(this.connection, alignedProxyPDAs);
     alignedProxyAccounts.forEach((account, index) => {
       if (account && account.data.length === ALIGNED_METADATA_ACC_SIZE) {
         const alignedData = streamRecord[alignedStreamsPubKeys[index]];


### PR DESCRIPTION
`getMultipleAccountsInfo` has a limit of 100 accounts - This was causing calls to fail if someone has more than a 100 aligned/dynamic streams in the `incoming` or `outgoing` category. Added wrapper function that is going to batch these into smaller requests with max size of 100.
