### PR TITLE
Update GitHub Actions workflows to standardize build package steps

### DIFF
--- a/.github/workflows/gh-publish.yml
+++ b/.github/workflows/gh-publish.yml
@@ -40,6 +40,8 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: pnpm install
+      - name: 📦 Build packages
+        run: pnpm build
       - name: Git Identity
         run: |
           git config --global user.name 'github-actions[bot]'

--- a/.github/workflows/version-tests.yml
+++ b/.github/workflows/version-tests.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "pnpm"
       - name: 📂 Install dependencies
         run: pnpm install
-      - name: 📦 Build dependencies
+      - name: 📦 Build packages
         run: pnpm build
       - name: 🧪 Run Tests
         run: pnpm test


### PR DESCRIPTION
Build is required before validation step and prepublish scripts are too late