### PR TITLE
feat: support create v2, update idls to support stake boundaries, expose governor

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,8 @@
 {
-  "packages": ["packages/*"],
-  "version": "8.7.0",
+  "packages": [
+    "packages/*"
+  ],
+  "version": "8.8.0-alpha.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/solana/descriptor/fee_manager.ts
+++ b/packages/staking/solana/descriptor/fee_manager.ts
@@ -8,7 +8,7 @@ export type FeeManager = {
   "address": "FEELzfBhsWXTNJX53zZcDVfRNoFYZQ6cZA3jLiGVL16V",
   "metadata": {
     "name": "feeManager",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Stores Fees and other admin configuration for the Staking protocol"
   },

--- a/packages/staking/solana/descriptor/fee_manager.ts
+++ b/packages/staking/solana/descriptor/fee_manager.ts
@@ -8,7 +8,7 @@ export type FeeManager = {
   "address": "FEELzfBhsWXTNJX53zZcDVfRNoFYZQ6cZA3jLiGVL16V",
   "metadata": {
     "name": "feeManager",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Stores Fees and other admin configuration for the Staking protocol"
   },

--- a/packages/staking/solana/descriptor/governor.ts
+++ b/packages/staking/solana/descriptor/governor.ts
@@ -1,0 +1,938 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/governor.json`.
+ */
+export type Governor = {
+  "address": "GVERNASJFxi8vjjJtwCKYQTeN51XsV1y2B1ap1GtKrKR",
+  "metadata": {
+    "name": "governor",
+    "version": "2.3.0",
+    "spec": "0.1.0",
+    "description": "Governor program to allow users to vote with stake tokens"
+  },
+  "instructions": [
+    {
+      "name": "addProposal",
+      "discriminator": [
+        130,
+        139,
+        214,
+        107,
+        93,
+        13,
+        84,
+        152,
+      ],
+      "accounts": [
+        {
+          "name": "stakePool",
+          "docs": [
+            "The stake pool associated with the governor",
+          ],
+          "relations": [
+            "governor",
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor to which the proposal is being added",
+          ],
+          "writable": true
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The new proposal account to be created",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "governor"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              },
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the governor",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u32"
+        },
+        {
+          "name": "text",
+          "type": "string"
+        },
+        {
+          "name": "options",
+          "type": {
+            "vec": "string"
+          }
+        },
+        {
+          "name": "votingStartTs",
+          "type": "u64"
+        },
+        {
+          "name": "votingEndTs",
+          "type": "u64"
+        },
+      ]
+    },
+    {
+      "name": "changeAuthority",
+      "discriminator": [
+        50,
+        106,
+        66,
+        104,
+        99,
+        118,
+        145,
+        88,
+      ],
+      "accounts": [
+        {
+          "name": "governor",
+          "docs": [
+            "Reward Pool",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Current Authority",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "newAuthority"
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "createGovernor",
+      "discriminator": [
+        103,
+        30,
+        78,
+        252,
+        28,
+        128,
+        40,
+        3,
+      ],
+      "accounts": [
+        {
+          "name": "stakePool",
+          "docs": [
+            "The stake pool for which the governor is being created",
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor account to be created",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  111,
+                  114,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stakePool"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              },
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the stake pool",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u8"
+        },
+      ]
+    },
+    {
+      "name": "setActiveProposal",
+      "discriminator": [
+        41,
+        14,
+        222,
+        18,
+        33,
+        232,
+        43,
+        82,
+      ],
+      "accounts": [
+        {
+          "name": "governor",
+          "docs": [
+            "The governor for which to set the active proposal",
+          ],
+          "writable": true,
+          "relations": [
+            "proposal",
+          ]
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The proposal to set as active",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the governor",
+          ],
+          "signer": true
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "voteOnProposal",
+      "discriminator": [
+        188,
+        239,
+        13,
+        88,
+        119,
+        199,
+        251,
+        119,
+      ],
+      "accounts": [
+        {
+          "name": "stakePool",
+          "docs": [
+            "Original Stake Pool",
+          ],
+          "relations": [
+            "governor",
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor account that manages the voting process",
+          ],
+          "writable": true,
+          "relations": [
+            "proposal",
+          ]
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The proposal being voted on",
+          ]
+        },
+        {
+          "name": "vote",
+          "docs": [
+            "The vote account that will be created to record the vote",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "voter"
+              },
+            ]
+          }
+        },
+        {
+          "name": "stakeMintAccount",
+          "docs": [
+            "The user's stake token account that holds the stake tokens",
+          ]
+        },
+        {
+          "name": "voter",
+          "docs": [
+            "The user who is voting",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rentSponsor",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  110,
+                  116,
+                  45,
+                  115,
+                  112,
+                  111,
+                  110,
+                  115,
+                  111,
+                  114,
+                ]
+              },
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "eventAuthority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121,
+                ]
+              },
+            ]
+          }
+        },
+        {
+          "name": "program"
+        },
+      ],
+      "args": [
+        {
+          "name": "optionIndex",
+          "type": "u8"
+        },
+      ]
+    },
+  ],
+  "accounts": [
+    {
+      "name": "governor",
+      "discriminator": [
+        37,
+        136,
+        44,
+        80,
+        68,
+        85,
+        213,
+        178,
+      ]
+    },
+    {
+      "name": "proposal",
+      "discriminator": [
+        26,
+        94,
+        189,
+        187,
+        116,
+        136,
+        53,
+        33,
+      ]
+    },
+    {
+      "name": "stakePool",
+      "discriminator": [
+        121,
+        34,
+        206,
+        21,
+        79,
+        127,
+        255,
+        28,
+      ]
+    },
+    {
+      "name": "vote",
+      "discriminator": [
+        96,
+        91,
+        104,
+        57,
+        145,
+        35,
+        172,
+        155,
+      ]
+    },
+  ],
+  "events": [
+    {
+      "name": "voteEvent",
+      "discriminator": [
+        195,
+        71,
+        250,
+        105,
+        120,
+        119,
+        234,
+        134,
+      ]
+    },
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "arithmeticError",
+      "msg": "Arithmetic Error (overflow/underflow)"
+    },
+    {
+      "code": 6001,
+      "name": "unauthorized",
+      "msg": "Account is not authorized to execute this instruction"
+    },
+    {
+      "code": 6002,
+      "name": "invalidStakeMint",
+      "msg": "Provided Stake Mint does not equal the Pool Stake Mint"
+    },
+    {
+      "code": 6003,
+      "name": "invalidStakePool",
+      "msg": "Provided Stake Pool does not equal the Entry Stake Pool"
+    },
+    {
+      "code": 6004,
+      "name": "invalidGovernor",
+      "msg": "Provided Governor does not match the proposal Governor"
+    },
+    {
+      "code": 6005,
+      "name": "invalidProposalText",
+      "msg": "Invalid proposal text provided"
+    },
+    {
+      "code": 6006,
+      "name": "invalidProposalOptions",
+      "msg": "Invalid proposal options provided"
+    },
+    {
+      "code": 6007,
+      "name": "invalidProposalDuration",
+      "msg": "Invalid proposal duration"
+    },
+    {
+      "code": 6008,
+      "name": "proposalAlreadyActive",
+      "msg": "This proposal is already active"
+    },
+    {
+      "code": 6009,
+      "name": "votingNotStarted",
+      "msg": "Voting not started yet"
+    },
+    {
+      "code": 6010,
+      "name": "votingEnded",
+      "msg": "Voting has already ended"
+    },
+    {
+      "code": 6011,
+      "name": "invalidOptionIndex",
+      "msg": "Provided option is not a valid proposal option"
+    },
+    {
+      "code": 6012,
+      "name": "insufficientStakeTokens",
+      "msg": "Insufficient tokens for voting"
+    },
+  ],
+  "types": [
+    {
+      "name": "governor",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump Seed used to sign transactions",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce to support multiple governors for the same pool",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "stakePool",
+            "docs": [
+              "Stake Pool for which Reward Pool was added",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority of the Governor that can add proposals and set the current one",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "currentProposal",
+            "docs": [
+              "Address of the current proposal",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "totalProposals",
+            "docs": [
+              "Total number of created proposals",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128,
+              ]
+            }
+          },
+        ]
+      }
+    },
+    {
+      "name": "proposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce used to derive proposal address",
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "governor",
+            "docs": [
+              "Stake Pool for which Reward Pool was added",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "text",
+            "docs": [
+              "Text of the proposals we reserve up to 512 bytes (ascii symbols take 1 byte)",
+            ],
+            "type": "string"
+          },
+          {
+            "name": "options",
+            "docs": [
+              "Potential options that will be used when answering, we reserve enough space for up to 8x32 = 256 ascii symbols in total",
+            ],
+            "type": {
+              "vec": "string"
+            }
+          },
+          {
+            "name": "votingStartTs",
+            "docs": [
+              "Time when voting starts, 0 means that voting start immediately after proposal was created",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "votingEndTs",
+            "docs": [
+              "Time when voting ends, 0 means that voting will be possible anytime",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "createdTs",
+            "docs": [
+              "Time when proposal was created",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastActiveTs",
+            "docs": [
+              "Last time when proposal was made active",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64,
+              ]
+            }
+          },
+        ]
+      }
+    },
+    {
+      "name": "stakePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump Seed used to sign transactions",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce to differentiate pools for the same mint",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Mint of the Stake Pool",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Initial Creator",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Current authority",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "minWeight",
+            "docs": [
+              "The lowest weight awarded for staking, measured as a fraction of `1 / SCALE_FACTOR_BASE`.",
+              "For instance:",
+              "* `min_weight = 1 x SCALE_FACTOR_BASE` signifies a minimum multiplier of 1x for min staking duration",
+              "* `min_weight = 2 x SCALE_FACTOR_BASE` indicates a minimum multiplier of 2x for min staking duration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxWeight",
+            "docs": [
+              "The highest weight awarded for staking, measured as a fraction of `1 / SCALE_FACTOR_BASE`.",
+              "For instance:",
+              "* `max_weight = 1 x SCALE_FACTOR_BASE` signifies a max multiplier of 1x for max staking duration",
+              "* `max_weight = 2 x SCALE_FACTOR_BASE` indicates a max multiplier of 2x for max staking duration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minDuration",
+            "docs": [
+              "Min Duration of stake in seconds",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxDuration",
+            "docs": [
+              "Max Duration of stake in seconds, the more duration, the more weight the stake has",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "permissionless",
+            "docs": [
+              "Whether anyone can add Reward Pools or just admin",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Escrow Account that stores staked tokens",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "stakeMint",
+            "docs": [
+              "Stake Mint, will be returned in exchange for stake tokens",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "totalStake",
+            "docs": [
+              "Total number of Staked tokens",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalEffectiveStake",
+            "docs": [
+              "Total staked tokens accounting for each stake weight, does not equal `total_stake`,",
+              "represents a sum of effective stake multiplied by 10^9 for precision",
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "freezeStakeMint",
+            "docs": [
+              "Whether we should freeze stake mint token accounts",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "unstakePeriod",
+            "docs": [
+              "Period for unstaking, if set unstake at first should be requested, and the real unstake can only happen after this period",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalStakeCapped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remainingTotalStake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                37,
+              ]
+            }
+          },
+        ]
+      }
+    },
+    {
+      "name": "vote",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "docs": [
+              "Question to which vote was provided",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "docs": [
+              "Voter that voted on the proposal",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "optionIndex",
+            "docs": [
+              "Index of the option used for voting",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "weight",
+            "docs": [
+              "Weight of the vote, correspond to number of sTokens used",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "isSponsored",
+            "docs": [
+              "Whether the vote rent has been sponsored by the rent vault",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                63,
+              ]
+            }
+          },
+        ]
+      }
+    },
+    {
+      "name": "voteEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "governor",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "optionIndex",
+            "type": "u8"
+          },
+          {
+            "name": "value",
+            "type": "u64"
+          },
+        ]
+      }
+    },
+  ]
+};

--- a/packages/staking/solana/descriptor/governor.ts
+++ b/packages/staking/solana/descriptor/governor.ts
@@ -809,7 +809,7 @@ export type Governor = {
             "type": "u64"
           },
           {
-            "name": "totalStakeCapped",
+            "name": "isTotalStakeCapped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
             ],

--- a/packages/staking/solana/descriptor/governor.ts
+++ b/packages/staking/solana/descriptor/governor.ts
@@ -8,7 +8,7 @@ export type Governor = {
   "address": "GVERNASJFxi8vjjJtwCKYQTeN51XsV1y2B1ap1GtKrKR",
   "metadata": {
     "name": "governor",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Governor program to allow users to vote with stake tokens"
   },

--- a/packages/staking/solana/descriptor/idl/fee_manager.json
+++ b/packages/staking/solana/descriptor/idl/fee_manager.json
@@ -2,7 +2,7 @@
   "address": "FEELzfBhsWXTNJX53zZcDVfRNoFYZQ6cZA3jLiGVL16V",
   "metadata": {
     "name": "fee_manager",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Stores Fees and other admin configuration for the Staking protocol"
   },

--- a/packages/staking/solana/descriptor/idl/fee_manager.json
+++ b/packages/staking/solana/descriptor/idl/fee_manager.json
@@ -2,7 +2,7 @@
   "address": "FEELzfBhsWXTNJX53zZcDVfRNoFYZQ6cZA3jLiGVL16V",
   "metadata": {
     "name": "fee_manager",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Stores Fees and other admin configuration for the Staking protocol"
   },

--- a/packages/staking/solana/descriptor/idl/governor.json
+++ b/packages/staking/solana/descriptor/idl/governor.json
@@ -803,7 +803,7 @@
             "type": "u64"
           },
           {
-            "name": "total_stake_capped",
+            "name": "is_total_stake_capped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
             ],

--- a/packages/staking/solana/descriptor/idl/governor.json
+++ b/packages/staking/solana/descriptor/idl/governor.json
@@ -1,0 +1,932 @@
+{
+  "address": "GVERNASJFxi8vjjJtwCKYQTeN51XsV1y2B1ap1GtKrKR",
+  "metadata": {
+    "name": "governor",
+    "version": "2.3.0",
+    "spec": "0.1.0",
+    "description": "Governor program to allow users to vote with stake tokens"
+  },
+  "instructions": [
+    {
+      "name": "add_proposal",
+      "discriminator": [
+        130,
+        139,
+        214,
+        107,
+        93,
+        13,
+        84,
+        152
+      ],
+      "accounts": [
+        {
+          "name": "stake_pool",
+          "docs": [
+            "The stake pool associated with the governor"
+          ],
+          "relations": [
+            "governor"
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor to which the proposal is being added"
+          ],
+          "writable": true
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The new proposal account to be created"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "governor"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the governor"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u32"
+        },
+        {
+          "name": "text",
+          "type": "string"
+        },
+        {
+          "name": "options",
+          "type": {
+            "vec": "string"
+          }
+        },
+        {
+          "name": "voting_start_ts",
+          "type": "u64"
+        },
+        {
+          "name": "voting_end_ts",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "change_authority",
+      "discriminator": [
+        50,
+        106,
+        66,
+        104,
+        99,
+        118,
+        145,
+        88
+      ],
+      "accounts": [
+        {
+          "name": "governor",
+          "docs": [
+            "Reward Pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Current Authority"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "new_authority"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_governor",
+      "discriminator": [
+        103,
+        30,
+        78,
+        252,
+        28,
+        128,
+        40,
+        3
+      ],
+      "accounts": [
+        {
+          "name": "stake_pool",
+          "docs": [
+            "The stake pool for which the governor is being created"
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor account to be created"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stake_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the stake pool"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_active_proposal",
+      "discriminator": [
+        41,
+        14,
+        222,
+        18,
+        33,
+        232,
+        43,
+        82
+      ],
+      "accounts": [
+        {
+          "name": "governor",
+          "docs": [
+            "The governor for which to set the active proposal"
+          ],
+          "writable": true,
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The proposal to set as active"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authority of the governor"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vote_on_proposal",
+      "discriminator": [
+        188,
+        239,
+        13,
+        88,
+        119,
+        199,
+        251,
+        119
+      ],
+      "accounts": [
+        {
+          "name": "stake_pool",
+          "docs": [
+            "Original Stake Pool"
+          ],
+          "relations": [
+            "governor"
+          ]
+        },
+        {
+          "name": "governor",
+          "docs": [
+            "The governor account that manages the voting process"
+          ],
+          "writable": true,
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "proposal",
+          "docs": [
+            "The proposal being voted on"
+          ]
+        },
+        {
+          "name": "vote",
+          "docs": [
+            "The vote account that will be created to record the vote"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "voter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "stake_mint_account",
+          "docs": [
+            "The user's stake token account that holds the stake tokens"
+          ]
+        },
+        {
+          "name": "voter",
+          "docs": [
+            "The user who is voting"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_sponsor",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  110,
+                  116,
+                  45,
+                  115,
+                  112,
+                  111,
+                  110,
+                  115,
+                  111,
+                  114
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "option_index",
+          "type": "u8"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Governor",
+      "discriminator": [
+        37,
+        136,
+        44,
+        80,
+        68,
+        85,
+        213,
+        178
+      ]
+    },
+    {
+      "name": "Proposal",
+      "discriminator": [
+        26,
+        94,
+        189,
+        187,
+        116,
+        136,
+        53,
+        33
+      ]
+    },
+    {
+      "name": "StakePool",
+      "discriminator": [
+        121,
+        34,
+        206,
+        21,
+        79,
+        127,
+        255,
+        28
+      ]
+    },
+    {
+      "name": "Vote",
+      "discriminator": [
+        96,
+        91,
+        104,
+        57,
+        145,
+        35,
+        172,
+        155
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "VoteEvent",
+      "discriminator": [
+        195,
+        71,
+        250,
+        105,
+        120,
+        119,
+        234,
+        134
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "ArithmeticError",
+      "msg": "Arithmetic Error (overflow/underflow)"
+    },
+    {
+      "code": 6001,
+      "name": "Unauthorized",
+      "msg": "Account is not authorized to execute this instruction"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidStakeMint",
+      "msg": "Provided Stake Mint does not equal the Pool Stake Mint"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidStakePool",
+      "msg": "Provided Stake Pool does not equal the Entry Stake Pool"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidGovernor",
+      "msg": "Provided Governor does not match the proposal Governor"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidProposalText",
+      "msg": "Invalid proposal text provided"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidProposalOptions",
+      "msg": "Invalid proposal options provided"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidProposalDuration",
+      "msg": "Invalid proposal duration"
+    },
+    {
+      "code": 6008,
+      "name": "ProposalAlreadyActive",
+      "msg": "This proposal is already active"
+    },
+    {
+      "code": 6009,
+      "name": "VotingNotStarted",
+      "msg": "Voting not started yet"
+    },
+    {
+      "code": 6010,
+      "name": "VotingEnded",
+      "msg": "Voting has already ended"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidOptionIndex",
+      "msg": "Provided option is not a valid proposal option"
+    },
+    {
+      "code": 6012,
+      "name": "InsufficientStakeTokens",
+      "msg": "Insufficient tokens for voting"
+    }
+  ],
+  "types": [
+    {
+      "name": "Governor",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump Seed used to sign transactions"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce to support multiple governors for the same pool"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "stake_pool",
+            "docs": [
+              "Stake Pool for which Reward Pool was added"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority of the Governor that can add proposals and set the current one"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "current_proposal",
+            "docs": [
+              "Address of the current proposal"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_proposals",
+            "docs": [
+              "Total number of created proposals"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_buffer",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Proposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce used to derive proposal address"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "governor",
+            "docs": [
+              "Stake Pool for which Reward Pool was added"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "text",
+            "docs": [
+              "Text of the proposals we reserve up to 512 bytes (ascii symbols take 1 byte)"
+            ],
+            "type": "string"
+          },
+          {
+            "name": "options",
+            "docs": [
+              "Potential options that will be used when answering, we reserve enough space for up to 8x32 = 256 ascii symbols in total"
+            ],
+            "type": {
+              "vec": "string"
+            }
+          },
+          {
+            "name": "voting_start_ts",
+            "docs": [
+              "Time when voting starts, 0 means that voting start immediately after proposal was created"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "voting_end_ts",
+            "docs": [
+              "Time when voting ends, 0 means that voting will be possible anytime"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "created_ts",
+            "docs": [
+              "Time when proposal was created"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_active_ts",
+            "docs": [
+              "Last time when proposal was made active"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_buffer",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump Seed used to sign transactions"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Nonce to differentiate pools for the same mint"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Mint of the Stake Pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Initial Creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Current authority"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "min_weight",
+            "docs": [
+              "The lowest weight awarded for staking, measured as a fraction of `1 / SCALE_FACTOR_BASE`.",
+              "For instance:",
+              "* `min_weight = 1 x SCALE_FACTOR_BASE` signifies a minimum multiplier of 1x for min staking duration",
+              "* `min_weight = 2 x SCALE_FACTOR_BASE` indicates a minimum multiplier of 2x for min staking duration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_weight",
+            "docs": [
+              "The highest weight awarded for staking, measured as a fraction of `1 / SCALE_FACTOR_BASE`.",
+              "For instance:",
+              "* `max_weight = 1 x SCALE_FACTOR_BASE` signifies a max multiplier of 1x for max staking duration",
+              "* `max_weight = 2 x SCALE_FACTOR_BASE` indicates a max multiplier of 2x for max staking duration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_duration",
+            "docs": [
+              "Min Duration of stake in seconds"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_duration",
+            "docs": [
+              "Max Duration of stake in seconds, the more duration, the more weight the stake has"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "permissionless",
+            "docs": [
+              "Whether anyone can add Reward Pools or just admin"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Escrow Account that stores staked tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_mint",
+            "docs": [
+              "Stake Mint, will be returned in exchange for stake tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_stake",
+            "docs": [
+              "Total number of Staked tokens"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_effective_stake",
+            "docs": [
+              "Total staked tokens accounting for each stake weight, does not equal `total_stake`,",
+              "represents a sum of effective stake multiplied by 10^9 for precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "freeze_stake_mint",
+            "docs": [
+              "Whether we should freeze stake mint token accounts"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "unstake_period",
+            "docs": [
+              "Period for unstaking, if set unstake at first should be requested, and the real unstake can only happen after this period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_stake_capped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remaining_total_stake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "_buffer",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                37
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Vote",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "docs": [
+              "Question to which vote was provided"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "docs": [
+              "Voter that voted on the proposal"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "option_index",
+            "docs": [
+              "Index of the option used for voting"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "weight",
+            "docs": [
+              "Weight of the vote, correspond to number of sTokens used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "is_sponsored",
+            "docs": [
+              "Whether the vote rent has been sponsored by the rent vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "_buffer",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                63
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "governor",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "option_index",
+            "type": "u8"
+          },
+          {
+            "name": "value",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/staking/solana/descriptor/idl/governor.json
+++ b/packages/staking/solana/descriptor/idl/governor.json
@@ -2,7 +2,7 @@
   "address": "GVERNASJFxi8vjjJtwCKYQTeN51XsV1y2B1ap1GtKrKR",
   "metadata": {
     "name": "governor",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Governor program to allow users to vote with stake tokens"
   },

--- a/packages/staking/solana/descriptor/idl/reward_pool.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool.json
@@ -2,7 +2,7 @@
   "address": "RWRDdfRbi3339VgKxTAXg4cjyniF7cbhNbMxZWiSKmj",
   "metadata": {
     "name": "reward_pool",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Program to manage Reward Pools for Stake Pools and claim rewards from them"
   },

--- a/packages/staking/solana/descriptor/idl/reward_pool.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool.json
@@ -2,7 +2,7 @@
   "address": "RWRDdfRbi3339VgKxTAXg4cjyniF7cbhNbMxZWiSKmj",
   "metadata": {
     "name": "reward_pool",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Program to manage Reward Pools for Stake Pools and claim rewards from them"
   },
@@ -127,6 +127,225 @@
           ],
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim."
+          ],
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_rewards_as_worker",
+      "discriminator": [
+        120,
+        246,
+        117,
+        149,
+        120,
+        210,
+        52,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "reward_pool",
+          "docs": [
+            "Reward Pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "stake_pool",
+          "docs": [
+            "Stake Pool"
+          ],
+          "writable": true,
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "stake_entry",
+          "docs": [
+            "Stake Entry for which rewards are being claimed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_entry",
+          "docs": [
+            "Reward Entry that stores metadata about claimed rewards"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  45,
+                  101,
+                  110,
+                  116,
+                  114,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reward_pool"
+              },
+              {
+                "kind": "account",
+                "path": "stake_entry"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Reward Pool Vault that stores tokens"
+          ],
+          "writable": true,
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "stake_vault",
+          "writable": true
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "stake_mint_from",
+          "writable": true
+        },
+        {
+          "name": "claimant",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Auto unstake worker"
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "wdrwhnCv4pzW8beKsbPa4S2UDZrXenjg16KJdKSpb5u"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim."
+          ],
+          "writable": true,
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "stake_mint",
+          "docs": [
+            "Mint for sTokens issued by the stake pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "stake_pool_program",
+          "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "clawback",
+      "discriminator": [
+        111,
+        92,
+        142,
+        79,
+        33,
+        234,
+        82,
+        27
+      ],
+      "accounts": [
+        {
+          "name": "reward_pool",
+          "docs": [
+            "Reward Pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "stake_pool",
+          "docs": [
+            "Stake Pool to Which Reward Pool belongs"
+          ],
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Reward Pool Vault that stores tokens"
+          ],
+          "writable": true,
+          "relations": [
+            "reward_pool"
+          ]
+        },
+        {
+          "name": "to",
+          "docs": [
+            "Account to send the reward tokens to."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Current Authority"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "reward_pool"
+          ]
         },
         {
           "name": "mint",
@@ -912,7 +1131,7 @@
     {
       "code": 6002,
       "name": "InvalidRewardPeriod",
-      "msg": "Reward period should be more than 0"
+      "msg": "Reward period should be more than 0 and less or equal than staking duration if auto unstake is enabled"
     },
     {
       "code": 6003,
@@ -973,6 +1192,36 @@
       "code": 6014,
       "name": "InvalidLastClaimPeriod",
       "msg": "Invalid last claim period provided"
+    },
+    {
+      "code": 6015,
+      "name": "ClawbackNotPossible",
+      "msg": "Clawback is not possible for the provided Stake Pool"
+    },
+    {
+      "code": 6016,
+      "name": "ClawbackTooEarly",
+      "msg": "Clawback requested too early, wait for the Pool to expire and cooldown to pass"
+    },
+    {
+      "code": 6017,
+      "name": "UpdateNotPossible",
+      "msg": "Reward pool can not be updated"
+    },
+    {
+      "code": 6018,
+      "name": "EntryCreationNotPossibleAfterUnlock",
+      "msg": "Reward entry can not be created after stake has been unlocked for this reward pool"
+    },
+    {
+      "code": 6019,
+      "name": "RefundNotPossible",
+      "msg": "Refund not possible for this reward entry"
+    },
+    {
+      "code": 6020,
+      "name": "PoolCreationLimited",
+      "msg": "Pool creation limited, use nonce 0"
     }
   ],
   "types": [
@@ -1276,6 +1525,13 @@
             "type": "u64"
           },
           {
+            "name": "clawed_back_ts",
+            "docs": [
+              "Timestamp when reward pool was clawed back"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1283,7 +1539,7 @@
             "type": {
               "array": [
                 "u8",
-                48
+                40
               ]
             }
           }
@@ -1380,6 +1636,13 @@
             "type": "bool"
           },
           {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1387,7 +1650,7 @@
             "type": {
               "array": [
                 "u8",
-                39
+                38
               ]
             }
           }
@@ -1519,6 +1782,34 @@
             "type": "u64"
           },
           {
+            "name": "total_stake_capped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remaining_total_stake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1526,7 +1817,7 @@
             "type": {
               "array": [
                 "u8",
-                55
+                37
               ]
             }
           }

--- a/packages/staking/solana/descriptor/idl/reward_pool.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool.json
@@ -1782,7 +1782,7 @@
             "type": "u64"
           },
           {
-            "name": "total_stake_capped",
+            "name": "is_total_stake_capped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
             ],

--- a/packages/staking/solana/descriptor/idl/reward_pool.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool.json
@@ -1638,7 +1638,7 @@
           {
             "name": "auto_unstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account"
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
@@ -2,7 +2,7 @@
   "address": "RWRDyfZa6Rk9UYi85yjYYfGmoUqffLqjo6vZdFawEez",
   "metadata": {
     "name": "reward_pool_dynamic",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Reward pools with dynamic rewards distribution"
   },

--- a/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
@@ -2,7 +2,7 @@
   "address": "RWRDyfZa6Rk9UYi85yjYYfGmoUqffLqjo6vZdFawEez",
   "metadata": {
     "name": "reward_pool_dynamic",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Reward pools with dynamic rewards distribution"
   },
@@ -1516,6 +1516,13 @@
             "type": "bool"
           },
           {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1523,7 +1530,7 @@
             "type": {
               "array": [
                 "u8",
-                39
+                38
               ]
             }
           }
@@ -1655,6 +1662,34 @@
             "type": "u64"
           },
           {
+            "name": "total_stake_capped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remaining_total_stake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1662,7 +1697,7 @@
             "type": {
               "array": [
                 "u8",
-                55
+                37
               ]
             }
           }
@@ -1703,6 +1738,13 @@
             "type": "u64"
           },
           {
+            "name": "is_sponsored",
+            "docs": [
+              "Whether the vote rent has been sponsored by the rent vault"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1710,7 +1752,7 @@
             "type": {
               "array": [
                 "u8",
-                64
+                63
               ]
             }
           }

--- a/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
@@ -1518,7 +1518,7 @@
           {
             "name": "auto_unstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account"
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
+++ b/packages/staking/solana/descriptor/idl/reward_pool_dynamic.json
@@ -1662,7 +1662,7 @@
             "type": "u64"
           },
           {
-            "name": "total_stake_capped",
+            "name": "is_total_stake_capped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
             ],

--- a/packages/staking/solana/descriptor/idl/stake_pool.json
+++ b/packages/staking/solana/descriptor/idl/stake_pool.json
@@ -1900,7 +1900,7 @@
             "type": "u64"
           },
           {
-            "name": "total_stake_capped",
+            "name": "is_total_stake_capped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
             ],

--- a/packages/staking/solana/descriptor/idl/stake_pool.json
+++ b/packages/staking/solana/descriptor/idl/stake_pool.json
@@ -544,7 +544,7 @@
             "Stake Pool"
           ],
           "writable": true,
-          "address": "22LvhHuibHXSvxCmdo1J4vL6ALpP5AD4CjW3jdhV673Z"
+          "address": "Cja9f8JFS6sTgBqSRZGBrA2HDbUj4MZUGdtRYruKTeJp"
         },
         {
           "name": "stake_pool_to",
@@ -552,7 +552,7 @@
             "Stake Pool"
           ],
           "writable": true,
-          "address": "SgbTXkmua6esmwv9FuftqWwaiWypiQmzK5P6s93G4wL"
+          "address": "BXRBbWMkscNBZoBL4fgRk77GBUX9eVP4AendQEumtPi8"
         },
         {
           "name": "stake_entry_from",
@@ -1756,7 +1756,7 @@
           {
             "name": "auto_unstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account"
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/idl/stake_pool.json
+++ b/packages/staking/solana/descriptor/idl/stake_pool.json
@@ -2,7 +2,7 @@
   "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH",
   "metadata": {
     "name": "stake_pool",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Program to manage Stake Pools and stake/unstake tokens"
   },

--- a/packages/staking/solana/descriptor/idl/stake_pool.json
+++ b/packages/staking/solana/descriptor/idl/stake_pool.json
@@ -2,7 +2,7 @@
   "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH",
   "metadata": {
     "name": "stake_pool",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Program to manage Stake Pools and stake/unstake tokens"
   },
@@ -358,6 +358,174 @@
       ]
     },
     {
+      "name": "create_pool_v2",
+      "discriminator": [
+        133,
+        27,
+        21,
+        38,
+        67,
+        86,
+        91,
+        132
+      ],
+      "accounts": [
+        {
+          "name": "stake_pool",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Mint used for staking"
+          ]
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stake_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "stake_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stake_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "Stake Pool creator"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u8"
+        },
+        {
+          "name": "max_weight",
+          "type": "u64"
+        },
+        {
+          "name": "min_duration",
+          "type": "u64"
+        },
+        {
+          "name": "max_duration",
+          "type": "u64"
+        },
+        {
+          "name": "permissionless",
+          "type": "bool"
+        },
+        {
+          "name": "freeze_stake_mint",
+          "type": "bool"
+        },
+        {
+          "name": "unstake_period",
+          "type": "u64"
+        },
+        {
+          "name": "max_total_stake_cumulative",
+          "type": "u64"
+        },
+        {
+          "name": "expiry_ts",
+          "type": "u64"
+        },
+        {
+          "name": "auto_unstake",
+          "type": "bool"
+        }
+      ]
+    },
+    {
       "name": "migrate_entry",
       "discriminator": [
         239,
@@ -376,7 +544,7 @@
             "Stake Pool"
           ],
           "writable": true,
-          "address": "Cja9f8JFS6sTgBqSRZGBrA2HDbUj4MZUGdtRYruKTeJp"
+          "address": "22LvhHuibHXSvxCmdo1J4vL6ALpP5AD4CjW3jdhV673Z"
         },
         {
           "name": "stake_pool_to",
@@ -384,7 +552,7 @@
             "Stake Pool"
           ],
           "writable": true,
-          "address": "BXRBbWMkscNBZoBL4fgRk77GBUX9eVP4AendQEumtPi8"
+          "address": "SgbTXkmua6esmwv9FuftqWwaiWypiQmzK5P6s93G4wL"
         },
         {
           "name": "stake_entry_from",
@@ -816,7 +984,60 @@
           "docs": [
             "Token Account to transfer Stake Mint tokens to"
           ],
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "stake_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "payer",
@@ -929,7 +1150,60 @@
           "docs": [
             "Stake Mint Token account"
           ],
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "stake_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "vault",
@@ -1013,6 +1287,154 @@
           }
         }
       ]
+    },
+    {
+      "name": "unstake_as_worker",
+      "discriminator": [
+        18,
+        36,
+        224,
+        241,
+        46,
+        185,
+        228,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "stake_pool",
+          "writable": true,
+          "relations": [
+            "stake_entry"
+          ]
+        },
+        {
+          "name": "stake_entry",
+          "docs": [
+            "Entry that stores Stake Metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Stake Mint Token account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "stake_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Escrow Account that stores Staked tokens"
+          ],
+          "writable": true,
+          "relations": [
+            "stake_pool"
+          ]
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Auto unstake worker"
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "wdrwhnCv4pzW8beKsbPa4S2UDZrXenjg16KJdKSpb5u"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Original mint of staked tokens"
+          ],
+          "writable": true,
+          "relations": [
+            "stake_pool"
+          ]
+        },
+        {
+          "name": "stake_mint",
+          "docs": [
+            "Stake Mint used to exchanged Staked tokens to"
+          ],
+          "writable": true,
+          "relations": [
+            "stake_pool"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -1060,7 +1482,7 @@
     {
       "code": 6000,
       "name": "InvalidDuration",
-      "msg": "Minimum duration must be less than the maximum"
+      "msg": "Minimum duration must be less than the maximum, maximum should be a realistic number of seconds"
     },
     {
       "code": 6001,
@@ -1155,7 +1577,42 @@
     {
       "code": 6019,
       "name": "InvalidMinDuration",
-      "msg": "Minimum duration should be at least 1"
+      "msg": "Minimum duration should be at least 1, for auto-unstake 7 days at least"
+    },
+    {
+      "code": 6020,
+      "name": "AutoUnstakeNotPossible",
+      "msg": "Auto unstake is not possible with unstake period or with a permissionless pool"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidExpiry",
+      "msg": "Expiry can not be less than max duration"
+    },
+    {
+      "code": 6022,
+      "name": "StakePayerNotSupported",
+      "msg": "Separate payer account is not supported when staking in a pool with auto-unstake"
+    },
+    {
+      "code": 6023,
+      "name": "StakeAmountExceedsMax",
+      "msg": "Stake amount exceeds max total stake"
+    },
+    {
+      "code": 6024,
+      "name": "StakeDurationExceedsExpiry",
+      "msg": "Stake duration exceeds stake pool expiry"
+    },
+    {
+      "code": 6025,
+      "name": "AccountDelegateRevoked",
+      "msg": "Token account delegate has been revoked by staker, can't burn tokens"
+    },
+    {
+      "code": 6026,
+      "name": "RefundNotPossible",
+      "msg": "Refund not possible for this stake entry"
     }
   ],
   "types": [
@@ -1297,6 +1754,13 @@
             "type": "bool"
           },
           {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1304,7 +1768,7 @@
             "type": {
               "array": [
                 "u8",
-                39
+                38
               ]
             }
           }
@@ -1436,6 +1900,34 @@
             "type": "u64"
           },
           {
+            "name": "total_stake_capped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remaining_total_stake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_unstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration"
+            ],
+            "type": "bool"
+          },
+          {
             "name": "_buffer",
             "docs": [
               "Buffer for additional fields"
@@ -1443,7 +1935,7 @@
             "type": {
               "array": [
                 "u8",
-                55
+                37
               ]
             }
           }

--- a/packages/staking/solana/descriptor/reward_pool.ts
+++ b/packages/staking/solana/descriptor/reward_pool.ts
@@ -8,7 +8,7 @@ export type RewardPool = {
   "address": "RWRDdfRbi3339VgKxTAXg4cjyniF7cbhNbMxZWiSKmj",
   "metadata": {
     "name": "rewardPool",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Program to manage Reward Pools for Stake Pools and claim rewards from them"
   },

--- a/packages/staking/solana/descriptor/reward_pool.ts
+++ b/packages/staking/solana/descriptor/reward_pool.ts
@@ -1644,7 +1644,7 @@ export type RewardPool = {
           {
             "name": "autoUnstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account",
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/reward_pool.ts
+++ b/packages/staking/solana/descriptor/reward_pool.ts
@@ -1788,7 +1788,7 @@ export type RewardPool = {
             "type": "u64"
           },
           {
-            "name": "totalStakeCapped",
+            "name": "isTotalStakeCapped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
             ],

--- a/packages/staking/solana/descriptor/reward_pool.ts
+++ b/packages/staking/solana/descriptor/reward_pool.ts
@@ -8,7 +8,7 @@ export type RewardPool = {
   "address": "RWRDdfRbi3339VgKxTAXg4cjyniF7cbhNbMxZWiSKmj",
   "metadata": {
     "name": "rewardPool",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Program to manage Reward Pools for Stake Pools and claim rewards from them"
   },
@@ -133,6 +133,225 @@ export type RewardPool = {
           ],
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim.",
+          ],
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "tokenProgram"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "claimRewardsAsWorker",
+      "discriminator": [
+        120,
+        246,
+        117,
+        149,
+        120,
+        210,
+        52,
+        193,
+      ],
+      "accounts": [
+        {
+          "name": "rewardPool",
+          "docs": [
+            "Reward Pool",
+          ],
+          "writable": true
+        },
+        {
+          "name": "stakePool",
+          "docs": [
+            "Stake Pool",
+          ],
+          "writable": true,
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "stakeEntry",
+          "docs": [
+            "Stake Entry for which rewards are being claimed",
+          ],
+          "writable": true
+        },
+        {
+          "name": "rewardEntry",
+          "docs": [
+            "Reward Entry that stores metadata about claimed rewards",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  45,
+                  101,
+                  110,
+                  116,
+                  114,
+                  121,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "rewardPool"
+              },
+              {
+                "kind": "account",
+                "path": "stakeEntry"
+              },
+            ]
+          }
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Reward Pool Vault that stores tokens",
+          ],
+          "writable": true,
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "stakeVault",
+          "writable": true
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "stakeMintFrom",
+          "writable": true
+        },
+        {
+          "name": "claimant",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Auto unstake worker",
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "wdrwhnCv4pzW8beKsbPa4S2UDZrXenjg16KJdKSpb5u"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim.",
+          ],
+          "writable": true,
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "stakeMint",
+          "docs": [
+            "Mint for sTokens issued by the stake pool",
+          ],
+          "writable": true
+        },
+        {
+          "name": "stakePoolProgram",
+          "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH"
+        },
+        {
+          "name": "associatedTokenProgram",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "tokenProgram"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "clawback",
+      "discriminator": [
+        111,
+        92,
+        142,
+        79,
+        33,
+        234,
+        82,
+        27,
+      ],
+      "accounts": [
+        {
+          "name": "rewardPool",
+          "docs": [
+            "Reward Pool",
+          ],
+          "writable": true
+        },
+        {
+          "name": "stakePool",
+          "docs": [
+            "Stake Pool to Which Reward Pool belongs",
+          ],
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Reward Pool Vault that stores tokens",
+          ],
+          "writable": true,
+          "relations": [
+            "rewardPool",
+          ]
+        },
+        {
+          "name": "to",
+          "docs": [
+            "Account to send the reward tokens to.",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Current Authority",
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "rewardPool",
+          ]
         },
         {
           "name": "mint",
@@ -918,7 +1137,7 @@ export type RewardPool = {
     {
       "code": 6002,
       "name": "invalidRewardPeriod",
-      "msg": "Reward period should be more than 0"
+      "msg": "Reward period should be more than 0 and less or equal than staking duration if auto unstake is enabled"
     },
     {
       "code": 6003,
@@ -979,6 +1198,36 @@ export type RewardPool = {
       "code": 6014,
       "name": "invalidLastClaimPeriod",
       "msg": "Invalid last claim period provided"
+    },
+    {
+      "code": 6015,
+      "name": "clawbackNotPossible",
+      "msg": "Clawback is not possible for the provided Stake Pool"
+    },
+    {
+      "code": 6016,
+      "name": "clawbackTooEarly",
+      "msg": "Clawback requested too early, wait for the Pool to expire and cooldown to pass"
+    },
+    {
+      "code": 6017,
+      "name": "updateNotPossible",
+      "msg": "Reward pool can not be updated"
+    },
+    {
+      "code": 6018,
+      "name": "entryCreationNotPossibleAfterUnlock",
+      "msg": "Reward entry can not be created after stake has been unlocked for this reward pool"
+    },
+    {
+      "code": 6019,
+      "name": "refundNotPossible",
+      "msg": "Refund not possible for this reward entry"
+    },
+    {
+      "code": 6020,
+      "name": "poolCreationLimited",
+      "msg": "Pool creation limited, use nonce 0"
     },
   ],
   "types": [
@@ -1282,6 +1531,13 @@ export type RewardPool = {
             "type": "u64"
           },
           {
+            "name": "clawedBackTs",
+            "docs": [
+              "Timestamp when reward pool was clawed back",
+            ],
+            "type": "u64"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1289,7 +1545,7 @@ export type RewardPool = {
             "type": {
               "array": [
                 "u8",
-                48,
+                40,
               ]
             }
           },
@@ -1386,6 +1642,13 @@ export type RewardPool = {
             "type": "bool"
           },
           {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1393,7 +1656,7 @@ export type RewardPool = {
             "type": {
               "array": [
                 "u8",
-                39,
+                38,
               ]
             }
           },
@@ -1525,6 +1788,34 @@ export type RewardPool = {
             "type": "u64"
           },
           {
+            "name": "totalStakeCapped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remainingTotalStake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1532,7 +1823,7 @@ export type RewardPool = {
             "type": {
               "array": [
                 "u8",
-                55,
+                37,
               ]
             }
           },

--- a/packages/staking/solana/descriptor/reward_pool_dynamic.ts
+++ b/packages/staking/solana/descriptor/reward_pool_dynamic.ts
@@ -8,7 +8,7 @@ export type RewardPoolDynamic = {
   "address": "RWRDyfZa6Rk9UYi85yjYYfGmoUqffLqjo6vZdFawEez",
   "metadata": {
     "name": "rewardPoolDynamic",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Reward pools with dynamic rewards distribution"
   },
@@ -1522,6 +1522,13 @@ export type RewardPoolDynamic = {
             "type": "bool"
           },
           {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1529,7 +1536,7 @@ export type RewardPoolDynamic = {
             "type": {
               "array": [
                 "u8",
-                39,
+                38,
               ]
             }
           },
@@ -1661,6 +1668,34 @@ export type RewardPoolDynamic = {
             "type": "u64"
           },
           {
+            "name": "totalStakeCapped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remainingTotalStake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1668,7 +1703,7 @@ export type RewardPoolDynamic = {
             "type": {
               "array": [
                 "u8",
-                55,
+                37,
               ]
             }
           },
@@ -1709,6 +1744,13 @@ export type RewardPoolDynamic = {
             "type": "u64"
           },
           {
+            "name": "isSponsored",
+            "docs": [
+              "Whether the vote rent has been sponsored by the rent vault",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1716,7 +1758,7 @@ export type RewardPoolDynamic = {
             "type": {
               "array": [
                 "u8",
-                64,
+                63,
               ]
             }
           },

--- a/packages/staking/solana/descriptor/reward_pool_dynamic.ts
+++ b/packages/staking/solana/descriptor/reward_pool_dynamic.ts
@@ -8,7 +8,7 @@ export type RewardPoolDynamic = {
   "address": "RWRDyfZa6Rk9UYi85yjYYfGmoUqffLqjo6vZdFawEez",
   "metadata": {
     "name": "rewardPoolDynamic",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Reward pools with dynamic rewards distribution"
   },

--- a/packages/staking/solana/descriptor/reward_pool_dynamic.ts
+++ b/packages/staking/solana/descriptor/reward_pool_dynamic.ts
@@ -1668,7 +1668,7 @@ export type RewardPoolDynamic = {
             "type": "u64"
           },
           {
-            "name": "totalStakeCapped",
+            "name": "isTotalStakeCapped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
             ],

--- a/packages/staking/solana/descriptor/reward_pool_dynamic.ts
+++ b/packages/staking/solana/descriptor/reward_pool_dynamic.ts
@@ -1524,7 +1524,7 @@ export type RewardPoolDynamic = {
           {
             "name": "autoUnstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account",
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/stake_pool.ts
+++ b/packages/staking/solana/descriptor/stake_pool.ts
@@ -8,7 +8,7 @@ export type StakePool = {
   "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH",
   "metadata": {
     "name": "stakePool",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "spec": "0.1.0",
     "description": "Program to manage Stake Pools and stake/unstake tokens"
   },

--- a/packages/staking/solana/descriptor/stake_pool.ts
+++ b/packages/staking/solana/descriptor/stake_pool.ts
@@ -1906,7 +1906,7 @@ export type StakePool = {
             "type": "u64"
           },
           {
-            "name": "totalStakeCapped",
+            "name": "isTotalStakeCapped",
             "docs": [
               "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
             ],

--- a/packages/staking/solana/descriptor/stake_pool.ts
+++ b/packages/staking/solana/descriptor/stake_pool.ts
@@ -550,7 +550,7 @@ export type StakePool = {
             "Stake Pool",
           ],
           "writable": true,
-          "address": "22LvhHuibHXSvxCmdo1J4vL6ALpP5AD4CjW3jdhV673Z"
+          "address": "Cja9f8JFS6sTgBqSRZGBrA2HDbUj4MZUGdtRYruKTeJp"
         },
         {
           "name": "stakePoolTo",
@@ -558,7 +558,7 @@ export type StakePool = {
             "Stake Pool",
           ],
           "writable": true,
-          "address": "SgbTXkmua6esmwv9FuftqWwaiWypiQmzK5P6s93G4wL"
+          "address": "BXRBbWMkscNBZoBL4fgRk77GBUX9eVP4AendQEumtPi8"
         },
         {
           "name": "stakeEntryFrom",
@@ -1762,7 +1762,7 @@ export type StakePool = {
           {
             "name": "autoUnstake",
             "docs": [
-              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+              "Whether auto unstaking is enabled, copied from the stake pool for use in instructions that don't require the stake pool account",
             ],
             "type": "bool"
           },

--- a/packages/staking/solana/descriptor/stake_pool.ts
+++ b/packages/staking/solana/descriptor/stake_pool.ts
@@ -8,7 +8,7 @@ export type StakePool = {
   "address": "STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH",
   "metadata": {
     "name": "stakePool",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "spec": "0.1.0",
     "description": "Program to manage Stake Pools and stake/unstake tokens"
   },
@@ -364,6 +364,174 @@ export type StakePool = {
       ]
     },
     {
+      "name": "createPoolV2",
+      "discriminator": [
+        133,
+        27,
+        21,
+        38,
+        67,
+        86,
+        91,
+        132,
+      ],
+      "accounts": [
+        {
+          "name": "stakePool",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  112,
+                  111,
+                  111,
+                  108,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              },
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Mint used for staking",
+          ]
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stakePool"
+              },
+            ]
+          }
+        },
+        {
+          "name": "stakeMint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  45,
+                  109,
+                  105,
+                  110,
+                  116,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stakePool"
+              },
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "Stake Pool creator",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "tokenProgram"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u8"
+        },
+        {
+          "name": "maxWeight",
+          "type": "u64"
+        },
+        {
+          "name": "minDuration",
+          "type": "u64"
+        },
+        {
+          "name": "maxDuration",
+          "type": "u64"
+        },
+        {
+          "name": "permissionless",
+          "type": "bool"
+        },
+        {
+          "name": "freezeStakeMint",
+          "type": "bool"
+        },
+        {
+          "name": "unstakePeriod",
+          "type": "u64"
+        },
+        {
+          "name": "maxTotalStakeCumulative",
+          "type": "u64"
+        },
+        {
+          "name": "expiryTs",
+          "type": "u64"
+        },
+        {
+          "name": "autoUnstake",
+          "type": "bool"
+        },
+      ]
+    },
+    {
       "name": "migrateEntry",
       "discriminator": [
         239,
@@ -382,7 +550,7 @@ export type StakePool = {
             "Stake Pool",
           ],
           "writable": true,
-          "address": "Cja9f8JFS6sTgBqSRZGBrA2HDbUj4MZUGdtRYruKTeJp"
+          "address": "22LvhHuibHXSvxCmdo1J4vL6ALpP5AD4CjW3jdhV673Z"
         },
         {
           "name": "stakePoolTo",
@@ -390,7 +558,7 @@ export type StakePool = {
             "Stake Pool",
           ],
           "writable": true,
-          "address": "BXRBbWMkscNBZoBL4fgRk77GBUX9eVP4AendQEumtPi8"
+          "address": "SgbTXkmua6esmwv9FuftqWwaiWypiQmzK5P6s93G4wL"
         },
         {
           "name": "stakeEntryFrom",
@@ -822,7 +990,60 @@ export type StakePool = {
           "docs": [
             "Token Account to transfer Stake Mint tokens to",
           ],
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProgram"
+              },
+              {
+                "kind": "account",
+                "path": "stakeMint"
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
         },
         {
           "name": "payer",
@@ -935,7 +1156,60 @@ export type StakePool = {
           "docs": [
             "Stake Mint Token account",
           ],
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProgram"
+              },
+              {
+                "kind": "account",
+                "path": "stakeMint"
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
         },
         {
           "name": "vault",
@@ -1020,6 +1294,154 @@ export type StakePool = {
         },
       ]
     },
+    {
+      "name": "unstakeAsWorker",
+      "discriminator": [
+        18,
+        36,
+        224,
+        241,
+        46,
+        185,
+        228,
+        142,
+      ],
+      "accounts": [
+        {
+          "name": "stakePool",
+          "writable": true,
+          "relations": [
+            "stakeEntry",
+          ]
+        },
+        {
+          "name": "stakeEntry",
+          "docs": [
+            "Entry that stores Stake Metadata",
+          ],
+          "writable": true
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Stake Mint Token account",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProgram"
+              },
+              {
+                "kind": "account",
+                "path": "stakeMint"
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault",
+          "docs": [
+            "Escrow Account that stores Staked tokens",
+          ],
+          "writable": true,
+          "relations": [
+            "stakePool",
+          ]
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Auto unstake worker",
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "wdrwhnCv4pzW8beKsbPa4S2UDZrXenjg16KJdKSpb5u"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Original mint of staked tokens",
+          ],
+          "writable": true,
+          "relations": [
+            "stakePool",
+          ]
+        },
+        {
+          "name": "stakeMint",
+          "docs": [
+            "Stake Mint used to exchanged Staked tokens to",
+          ],
+          "writable": true,
+          "relations": [
+            "stakePool",
+          ]
+        },
+        {
+          "name": "associatedTokenProgram",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "tokenProgram"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": []
+    },
   ],
   "accounts": [
     {
@@ -1066,7 +1488,7 @@ export type StakePool = {
     {
       "code": 6000,
       "name": "invalidDuration",
-      "msg": "Minimum duration must be less than the maximum"
+      "msg": "Minimum duration must be less than the maximum, maximum should be a realistic number of seconds"
     },
     {
       "code": 6001,
@@ -1161,7 +1583,42 @@ export type StakePool = {
     {
       "code": 6019,
       "name": "invalidMinDuration",
-      "msg": "Minimum duration should be at least 1"
+      "msg": "Minimum duration should be at least 1, for auto-unstake 7 days at least"
+    },
+    {
+      "code": 6020,
+      "name": "autoUnstakeNotPossible",
+      "msg": "Auto unstake is not possible with unstake period or with a permissionless pool"
+    },
+    {
+      "code": 6021,
+      "name": "invalidExpiry",
+      "msg": "Expiry can not be less than max duration"
+    },
+    {
+      "code": 6022,
+      "name": "stakePayerNotSupported",
+      "msg": "Separate payer account is not supported when staking in a pool with auto-unstake"
+    },
+    {
+      "code": 6023,
+      "name": "stakeAmountExceedsMax",
+      "msg": "Stake amount exceeds max total stake"
+    },
+    {
+      "code": 6024,
+      "name": "stakeDurationExceedsExpiry",
+      "msg": "Stake duration exceeds stake pool expiry"
+    },
+    {
+      "code": 6025,
+      "name": "accountDelegateRevoked",
+      "msg": "Token account delegate has been revoked by staker, can't burn tokens"
+    },
+    {
+      "code": 6026,
+      "name": "refundNotPossible",
+      "msg": "Refund not possible for this stake entry"
     },
   ],
   "types": [
@@ -1303,6 +1760,13 @@ export type StakePool = {
             "type": "bool"
           },
           {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, copied from stake pool to be used instruction that don't require stake pool",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1310,7 +1774,7 @@ export type StakePool = {
             "type": {
               "array": [
                 "u8",
-                39,
+                38,
               ]
             }
           },
@@ -1442,6 +1906,34 @@ export type StakePool = {
             "type": "u64"
           },
           {
+            "name": "totalStakeCapped",
+            "docs": [
+              "Whether amount of total staked tokens is limited by `remaining_total_stake` - stored as separate flag to not deal with `Option`",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "remainingTotalStake",
+            "docs": [
+              "Remaining total amount of staked tokens (cumulative)",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "Time when stake pool expires, staking is not possible after expiration",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "autoUnstake",
+            "docs": [
+              "Whether auto unstaking is enabled, stake entries will be unstaked after duration",
+            ],
+            "type": "bool"
+          },
+          {
             "name": "buffer",
             "docs": [
               "Buffer for additional fields",
@@ -1449,7 +1941,7 @@ export type StakePool = {
             "type": {
               "array": [
                 "u8",
-                55,
+                37,
               ]
             }
           },

--- a/packages/staking/solana/types.ts
+++ b/packages/staking/solana/types.ts
@@ -115,5 +115,8 @@ export interface CreateStakePoolArgs extends TokenProgram {
   permissionless?: boolean;
   freezeStakeMint?: boolean | null;
   unstakePeriod?: BN | null;
+  maxTotalStakeCumulative?: BN;
+  expiryTs?: BN;
+  autoUnstake?: boolean;
   authority?: Keypair;
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "8.7.0",
+  "version": "8.8.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "8.8.0-alpha.0",
+  "version": "8.8.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
- add new stake pool boundaries - expiry, max stake, auto unstake;
- support create v2 in stake pools if new options are provided;
- update idls to support new options in accounts;
- expose governor idl;

This is an alpha-version, as changes are only on devnet for now.