### PR TITLE
Dynamic Airdop fees

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,15 @@
       "pattern": "./packages/*/"
     }
   ],
-  "cSpell.words": ["Blockhash", "merkle", "permissionless", "Solana", "Streamflow", "Unstake"],
+  "cSpell.words": [
+    "Blockhash",
+    "lamports",
+    "merkle",
+    "permissionless",
+    "Solana",
+    "Streamflow",
+    "Unstake"
+  ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "javascript.preferences.importModuleSpecifierEnding": "js",
   "typescript.preferences.importModuleSpecifierEnding": "js",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "8.9.0",
+  "version": "9.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,5 @@
   "version": "4.0.1",
   "engines": {
     "node": ">=18"
-  },
-  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
   "version": "4.0.1",
   "engines": {
     "node": ">=18"
-  }
+  },
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./lib/assertions.js";
 export * from "./lib/utils.js";
+export * from "./lib/fetch-token-price.js";

--- a/packages/common/lib/fetch-token-price.ts
+++ b/packages/common/lib/fetch-token-price.ts
@@ -65,4 +65,3 @@ export function getTokenPriceQueryOptions(
   };
 }
 
-

--- a/packages/common/lib/fetch-token-price.ts
+++ b/packages/common/lib/fetch-token-price.ts
@@ -1,10 +1,10 @@
 import { ICluster } from "../types.js";
 
 export type TokensPricesResponse = {
-  data: Record<string, { id: string; value: number | undefined }>;
+  data: Record<string, TokenPriceResult>;
 };
 
-export type TokenPriceResult = { id: string; value: number | null };
+export type TokenPriceResult = { id: string; value: number | undefined };
 
 export interface FetchTokenPriceOptions {
   fetchImpl?: typeof fetch;
@@ -34,7 +34,7 @@ export const fetchTokenPrice = async (
     }
     const json = (await res.json()) as TokensPricesResponse;
     const entry = json?.data?.[mintId];
-    return { id: mintId, value: typeof entry?.value === "number" ? entry.value : null };
+    return { id: mintId, value: typeof entry?.value === "number" ? entry.value : undefined };
   } finally {
     if (timeout) clearTimeout(timeout);
   }

--- a/packages/common/lib/fetch-token-price.ts
+++ b/packages/common/lib/fetch-token-price.ts
@@ -1,0 +1,68 @@
+import { ICluster } from "../types.js";
+
+export type TokensPricesResponse = {
+  data: Record<string, { id: string; value: number | undefined }>;
+};
+
+export type TokenPriceResult = { id: string; value: number | null };
+
+export interface FetchTokenPriceOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export const fetchTokenPrice = async (
+  mintId: string,
+  cluster: ICluster = ICluster.Mainnet,
+  options?: FetchTokenPriceOptions,
+): Promise<TokenPriceResult> => {
+  const url = `https://token-api.streamflow.finance/price?ids=${encodeURIComponent(mintId)}&cluster=${encodeURIComponent(cluster)}`;
+
+  const impl = options?.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = options?.timeoutMs
+    ? setTimeout(() => controller.abort(), options.timeoutMs)
+    : undefined;
+
+  try {
+    const res = await impl(url, {
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`Price API error: ${res.status} ${res.statusText}`);
+    }
+    const json = (await res.json()) as TokensPricesResponse;
+    const entry = json?.data?.[mintId];
+    return { id: mintId, value: typeof entry?.value === "number" ? entry.value : null };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+};
+
+export interface TokenPriceQueryOptionsOverrides {
+  staleTimeMs?: number;
+  gcTimeMs?: number;
+  retry?: number | boolean;
+  refetchOnWindowFocus?: boolean;
+}
+
+export function getTokenPriceQueryOptions(
+  mintId: string,
+  cluster: ICluster = ICluster.Mainnet,
+  options?: FetchTokenPriceOptions & TokenPriceQueryOptionsOverrides,
+) {
+  const { staleTimeMs = 60_000, gcTimeMs = 300_000, retry = 2, refetchOnWindowFocus = false, ...rest } =
+    options ?? {};
+  const key = ["sf", "price", cluster, mintId];
+  return {
+    queryKey: key,
+    queryFn: () => fetchTokenPrice(mintId, cluster, rest),
+    staleTime: staleTimeMs,
+    gcTime: gcTimeMs,
+    retry,
+    refetchOnWindowFocus,
+  };
+}
+
+

--- a/packages/common/lib/fetch-token-price.ts
+++ b/packages/common/lib/fetch-token-price.ts
@@ -39,29 +39,3 @@ export const fetchTokenPrice = async (
     if (timeout) clearTimeout(timeout);
   }
 };
-
-export interface TokenPriceQueryOptionsOverrides {
-  staleTimeMs?: number;
-  gcTimeMs?: number;
-  retry?: number | boolean;
-  refetchOnWindowFocus?: boolean;
-}
-
-export function getTokenPriceQueryOptions(
-  mintId: string,
-  cluster: ICluster = ICluster.Mainnet,
-  options?: FetchTokenPriceOptions & TokenPriceQueryOptionsOverrides,
-) {
-  const { staleTimeMs = 60_000, gcTimeMs = 300_000, retry = 2, refetchOnWindowFocus = false, ...rest } =
-    options ?? {};
-  const key = ["sf", "price", cluster, mintId];
-  return {
-    queryKey: key,
-    queryFn: () => fetchTokenPrice(mintId, cluster, rest),
-    staleTime: staleTimeMs,
-    gcTime: gcTimeMs,
-    retry,
-    refetchOnWindowFocus,
-  };
-}
-

--- a/packages/common/lib/utils.ts
+++ b/packages/common/lib/utils.ts
@@ -61,3 +61,22 @@ export function sleep(ms: number): Promise<void> {
 }
 
 export const divCeilN = (n: bigint, d: bigint): bigint => n / d + (n % d ? BigInt(1) : BigInt(0));
+
+/**
+ * Multiply a bigint by a JS number using string-based fixed-point to avoid overflow/precision issues.
+ * Returns floor(x * y).
+ */
+export function multiplyBigIntByNumber(x: bigint, y: number, scaleDigits = 9): bigint {
+  if (!Number.isFinite(y) || y === 0) return 0n;
+  const isNegative = (x < 0n) !== (y < 0);
+  const absX = x < 0n ? -x : x;
+  const absY = Math.abs(y);
+
+  const s = absY.toFixed(scaleDigits);
+  const [intPart, fracPartRaw = ""] = s.split(".");
+  const fracPart = fracPartRaw.padEnd(scaleDigits, "0").slice(0, scaleDigits);
+  const yScaled = BigInt(intPart + fracPart); // absY * 10^scaleDigits
+  const scale = 10n ** BigInt(scaleDigits);
+  const product = (absX * yScaled) / scale;
+  return isNegative ? -product : product;
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -34,6 +34,7 @@ import {
   DISTRIBUTOR_PROGRAM_ID,
   STREAMFLOW_TREASURY_PUBLIC_KEY,
 } from "../constants.js";
+import { MINIMUM_FEE_FALLBACK, resolveAirdropFeeLamportsUsingApi } from "../fees.js";
 import MerkleDistributorIDL from "../descriptor/idl/merkle_distributor.json";
 import type { MerkleDistributor as MerkleDistributorProgramType } from "../descriptor/merkle_distributor.js";
 import { MerkleDistributor } from "../generated/accounts/index.js";
@@ -90,6 +91,8 @@ export default abstract class BaseDistributorClient {
 
   public merkleDistributorProgram: Program<MerkleDistributorProgramType>;
 
+  protected cluster: ICluster;
+
   public constructor({
     clusterUrl,
     cluster = ICluster.Mainnet,
@@ -99,6 +102,7 @@ export default abstract class BaseDistributorClient {
     sendThrottler,
   }: IInitOptions) {
     this.commitment = commitment;
+    this.cluster = cluster;
     this.connection = new Connection(clusterUrl, this.commitment);
     this.programId = programId !== "" ? new PublicKey(programId) : new PublicKey(DISTRIBUTOR_PROGRAM_ID[cluster]);
     this.sendThrottler = sendThrottler ?? buildSendThrottler(sendRate);
@@ -360,12 +364,23 @@ export default abstract class BaseDistributorClient {
       ixs.push(claimLocked(accounts, this.programId));
     }
 
-    ixs.push(
-      this.prepareClaimFeeInstruction(
-        extParams.feePayer ?? extParams.invoker.publicKey,
-        typeof _serviceTransfer === "bigint" ? _serviceTransfer : undefined,
-      ),
-    );
+    // Determine fee: prefer service internal (if provided by service), else fetch params from API
+    // and compute dynamically through resolver, else default minimum
+    let feeLamports = typeof _serviceTransfer === "bigint" ? _serviceTransfer : undefined;
+    if (!feeLamports) {
+      try {
+        const { mint: mintAccount } = await getMintAndProgram(this.connection, distributor.mint);
+        feeLamports = await resolveAirdropFeeLamportsUsingApi({
+          distributorAddress: distributorPublicKey.toBase58(),
+          mintAccount,
+          claimableAmount: BigInt(data.claimableAmount.toString()),
+          cluster: this.cluster,
+        });
+      } catch (_) {
+        feeLamports = MINIMUM_FEE_FALLBACK;
+      }
+    }
+    ixs.push(this.prepareClaimFeeInstruction(extParams.feePayer ?? extParams.invoker.publicKey, feeLamports));
 
     return ixs;
   }

--- a/packages/distributor/solana/fees.ts
+++ b/packages/distributor/solana/fees.ts
@@ -1,0 +1,212 @@
+import { ICluster } from "@streamflow/common";
+import { fetchAirdropFee } from "./fetchAirdropFee.js";
+import type { Mint } from "@solana/spl-token";
+export const MAXIMUM_FEE_FALLBACK = 9_900_000n; // 0.0099 SOL
+export const MINIMUM_FEE_FALLBACK = 5_000_000n; // 0.005 SOL
+export const FEE_ALLOCATION_FACTOR_FALLBACK_NUMERATOR = 90n; // 90%
+export const FEE_ALLOCATION_FACTOR_FALLBACK_DENOMINATOR = 100n;
+
+const lamportsToSolString = (lamports: bigint): string => {
+  const s = (Number(lamports) / 1e9).toFixed(9);
+  return s.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+};
+const allocationToString = (num: bigint, den: bigint): string => (Number(num) / Number(den)).toString();
+
+const defaultAPIFeesResponse: AirdropFeeServiceResponse = {
+  isCustom: false,
+  claimFee: undefined,
+  claimFeeDynamic: {
+    minPrice: lamportsToSolString(MINIMUM_FEE_FALLBACK),
+    maxPrice: lamportsToSolString(MAXIMUM_FEE_FALLBACK),
+    allocationFactor: allocationToString(
+      FEE_ALLOCATION_FACTOR_FALLBACK_NUMERATOR,
+      FEE_ALLOCATION_FACTOR_FALLBACK_DENOMINATOR,
+    ),
+  },
+} as const;
+
+export type AirdropFeeDynamic = {
+  minPrice: string;
+  maxPrice: string;
+  allocationFactor: string; // 0..1 in string
+};
+
+export type AirdropFeeServiceResponse = {
+  isCustom?: boolean;
+  claimFee?: string | number; // SOL units as string/number
+  claimFeeDynamic?: AirdropFeeDynamic;
+};
+
+export type AirdropFeeClient = {
+  getAirdropFee: (distributorAddress: string) => Promise<{ data?: AirdropFeeServiceResponse }>;
+};
+
+export const toBigInt = (v: string | number | bigint | undefined): bigint | undefined =>
+  v === undefined ? undefined : BigInt(v);
+
+export const toLamportsSOL = (value: string | number | bigint, solDecimals = 9): bigint => {
+  const num = typeof value === "bigint" ? Number(value) : Number(value);
+  const scale = 10 ** solDecimals;
+  return BigInt(Math.floor(Math.max(0, num) * scale));
+};
+
+export const applyFeeLogic = (baseLamports: bigint): bigint => {
+  if (baseLamports <= 0n) {
+    return MINIMUM_FEE_FALLBACK;
+  }
+  const raw = (baseLamports * FEE_ALLOCATION_FACTOR_FALLBACK_NUMERATOR) / FEE_ALLOCATION_FACTOR_FALLBACK_DENOMINATOR;
+  if (raw < MINIMUM_FEE_FALLBACK) return MINIMUM_FEE_FALLBACK;
+  if (raw > MAXIMUM_FEE_FALLBACK) return MAXIMUM_FEE_FALLBACK;
+  return raw;
+};
+
+export async function calculateAirdropFeeLamports(params: {
+  distributorAddress: string;
+  client?: AirdropFeeClient;
+  claimableLamports?: bigint; // optional estimated claimable amount in lamports
+}): Promise<bigint> {
+  const { distributorAddress, client, claimableLamports } = params;
+
+  try {
+    if (client) {
+      const res = await client.getAirdropFee(distributorAddress);
+      const data = res?.data;
+      if (data?.isCustom && data.claimFee !== undefined) {
+        return toLamportsSOL(data.claimFee);
+      }
+      if (data?.claimFeeDynamic && claimableLamports !== undefined) {
+        const min = toLamportsSOL(data.claimFeeDynamic.minPrice);
+        const max = toLamportsSOL(data.claimFeeDynamic.maxPrice);
+        const factor = Math.max(0, Math.min(1, parseFloat(data.claimFeeDynamic.allocationFactor)));
+        const fee = BigInt(Math.floor(Number(claimableLamports) * factor));
+        if (fee < min) return min;
+        if (fee > max) return max;
+        return fee;
+      }
+    }
+  } catch (_err) {
+    // Ignore and fallback
+  }
+
+  if (claimableLamports !== undefined) {
+    return applyFeeLogic(claimableLamports);
+  }
+  return MINIMUM_FEE_FALLBACK;
+}
+
+/**
+ * Calculates claimable SOL lamports from:
+ * - claimable token amount in the token's base units (BN or bigint)
+ * - token USD price and SOL USD price
+ * - token decimals
+ */
+export function calculateClaimableLamportsFromPrices(params: {
+  claimableAmount: bigint;
+  tokenPriceUsd: number;
+  solPriceUsd: number;
+  tokenDecimals: number;
+  solDecimals?: number; // default 9
+}): bigint {
+  const {
+    claimableAmount: claimableAmountBaseUnits,
+    tokenPriceUsd,
+    solPriceUsd,
+    tokenDecimals,
+    solDecimals = 9,
+  } = params;
+  if (tokenPriceUsd <= 0 || solPriceUsd <= 0) return 0n;
+  const decimalsDiff = BigInt(Math.max(0, solDecimals - tokenDecimals));
+  const scaled = claimableAmountBaseUnits * BigInt(10) ** decimalsDiff;
+  const usdValueScaled = BigInt(Math.floor(Number(scaled) * tokenPriceUsd));
+  // divide by SOL price (avoid floating by scaling first)
+  const lamports = BigInt(Math.floor(Number(usdValueScaled) / solPriceUsd));
+  return lamports;
+}
+
+/**
+ * Calculates lamport fee using dynamic SOL parameters coming from backend
+ * minPrice/maxPrice/allocationFactor are strings from API; prices are in SOL units
+ */
+export function calculateDynamicFeeFromSolParams(params: {
+  minPrice: string;
+  maxPrice: string;
+  allocationFactor: string; // e.g. "0.9"
+  claimableLamports: bigint;
+  solDecimals?: number; // default 9
+}): bigint {
+  const { minPrice, maxPrice, allocationFactor, claimableLamports, solDecimals = 9 } = params;
+  const minLamports = toLamportsSOL(minPrice, solDecimals);
+  const maxLamports = toLamportsSOL(maxPrice, solDecimals);
+  const factor = Math.max(0, Math.min(1, parseFloat(allocationFactor)));
+  const raw = BigInt(Math.floor(Number(claimableLamports) * factor));
+  if (raw < minLamports) return minLamports;
+  if (raw > maxLamports) return maxLamports;
+  return raw;
+}
+
+async function fetchTokenPriceUsd(
+  mintId: string,
+  cluster: ICluster,
+  fetchFn: typeof fetch = fetch,
+): Promise<number | null> {
+  const url = `https://token-api.streamflow.finance/price?ids=${encodeURIComponent(mintId)}&cluster=${encodeURIComponent(cluster)}`;
+  const res = await fetchFn(url, { headers: { "Content-Type": "application/json" } });
+  if (!res.ok) return null;
+  const json = (await res.json()) as { data?: Record<string, { id: string; value?: number }> };
+  const val = json?.data?.[mintId]?.value;
+  return typeof val === "number" ? val : null;
+}
+
+export async function resolveAirdropFeeLamportsUsingApi(params: {
+  distributorAddress: string;
+  mintAccount: Mint;
+  claimableAmount: bigint;
+  cluster: ICluster;
+  fetchFn?: typeof fetch;
+}): Promise<bigint> {
+  const { distributorAddress, mintAccount, claimableAmount, cluster, fetchFn } = params;
+  let apiFeesResponse = undefined;
+
+  try {
+    apiFeesResponse = await fetchAirdropFee(distributorAddress, cluster);
+  } catch (_) {
+    // ignore and fallback
+  }
+
+  let solPrice = null;
+  let tokenPrice = null;
+  try {
+    [solPrice, tokenPrice] = await Promise.all([
+      fetchTokenPriceUsd("So11111111111111111111111111111111111111112", cluster, fetchFn),
+      fetchTokenPriceUsd(mintAccount.address.toBase58(), cluster, fetchFn),
+    ]);
+  } catch (_) {
+    // ignore and fallback
+  }
+
+  const response = apiFeesResponse ?? defaultAPIFeesResponse;
+
+  if (response?.isCustom && response.claimFee !== undefined) {
+    return toLamportsSOL(response.claimFee);
+  }
+
+  const claimFeeDynamic = response?.claimFeeDynamic ?? defaultAPIFeesResponse.claimFeeDynamic;
+
+  if (!tokenPrice || !solPrice) {
+    return MINIMUM_FEE_FALLBACK;
+  }
+
+  const baseLamports = calculateClaimableLamportsFromPrices({
+    claimableAmount: claimableAmount,
+    tokenPriceUsd: tokenPrice,
+    solPriceUsd: solPrice,
+    tokenDecimals: mintAccount.decimals,
+  });
+
+  return calculateDynamicFeeFromSolParams({
+    minPrice: claimFeeDynamic!.minPrice,
+    maxPrice: claimFeeDynamic!.maxPrice,
+    allocationFactor: claimFeeDynamic!.allocationFactor,
+    claimableLamports: baseLamports,
+  });
+}

--- a/packages/distributor/solana/fees.ts
+++ b/packages/distributor/solana/fees.ts
@@ -1,5 +1,6 @@
 import { type ICluster, multiplyBigIntByNumber, fetchTokenPrice } from "@streamflow/common";
 import type { Mint } from "@solana/spl-token";
+import { NATIVE_MINT } from "@solana/spl-token";
 
 import { fetchAirdropFee } from "./fetchAirdropFee.js";
 
@@ -56,9 +57,6 @@ const defaultAPIFeesResponse: AirdropFeeServiceResponse = {
     ),
   },
 } as const;
-
-export const toBigInt = (v: string | number | bigint | undefined): bigint | undefined =>
-  v === undefined ? undefined : BigInt(v);
 
 export const toLamportsSOL = (value: string | number | bigint, solDecimals = 9): bigint => {
   const y = typeof value === "bigint" ? Number(value) : typeof value === "string" ? Number(value) : value;
@@ -183,7 +181,7 @@ export async function resolveAirdropFeeLamportsUsingApi(params: {
   let tokenPrice = null;
   try {
     [solPrice, tokenPrice] = await Promise.all([
-        fetchTokenPrice("So11111111111111111111111111111111111111112", cluster),
+        fetchTokenPrice(NATIVE_MINT.toBase58(), cluster),
         fetchTokenPrice(mintAccount.address.toBase58(), cluster),
     ]);
   } catch (_) {

--- a/packages/distributor/solana/fees.ts
+++ b/packages/distributor/solana/fees.ts
@@ -1,6 +1,8 @@
-import { ICluster } from "@streamflow/common";
-import { fetchAirdropFee } from "./fetchAirdropFee.js";
+import { type ICluster } from "@streamflow/common";
 import type { Mint } from "@solana/spl-token";
+
+import { fetchAirdropFee } from "./fetchAirdropFee.js";
+
 export const MAXIMUM_FEE_FALLBACK = 9_900_000n; // 0.0099 SOL
 export const MINIMUM_FEE_FALLBACK = 5_000_000n; // 0.005 SOL
 export const FEE_ALLOCATION_FACTOR_FALLBACK_NUMERATOR = 90n; // 90%

--- a/packages/distributor/solana/fetchAirdropFee.ts
+++ b/packages/distributor/solana/fetchAirdropFee.ts
@@ -58,4 +58,3 @@ export function getAirdropFeeQueryOptions(
   };
 }
 
-

--- a/packages/distributor/solana/fetchAirdropFee.ts
+++ b/packages/distributor/solana/fetchAirdropFee.ts
@@ -1,3 +1,5 @@
+import { ICluster } from "@streamflow/common";
+
 export type AirdropFeeResponse = {
   claimFee: string | number;
   claimFeeDynamic?: {
@@ -8,14 +10,20 @@ export type AirdropFeeResponse = {
   isCustom: boolean;
 };
 
-import { ICluster } from "@streamflow/common";
+export interface AirdropFeeQueryOptionsOverrides {
+  staleTimeMs?: number;
+  gcTimeMs?: number;
+  retry?: number | boolean;
+  refetchOnWindowFocus?: boolean;
+}
 
 export const fetchAirdropFee = async (
   distributorId: string,
   cluster: ICluster = ICluster.Mainnet,
   fetchFn: typeof fetch = fetch,
 ): Promise<AirdropFeeResponse> => {
-  const baseUrl = cluster === ICluster.Mainnet ? "https://api.streamflow.finance" : "https://staging-api.streamflow.finance";
+  const baseUrl =
+    cluster === ICluster.Mainnet ? "https://api.streamflow.finance" : "https://staging-api.streamflow.finance";
   const url = `${baseUrl}/v2/api/airdrops/${encodeURIComponent(distributorId)}/fees`;
 
   const res = await fetchFn(url, {
@@ -33,28 +41,3 @@ export const fetchAirdropFee = async (
   const json = (await res.json()) as AirdropFeeResponse;
   return json;
 };
-
-export interface AirdropFeeQueryOptionsOverrides {
-  staleTimeMs?: number;
-  gcTimeMs?: number;
-  retry?: number | boolean;
-  refetchOnWindowFocus?: boolean;
-}
-
-export function getAirdropFeeQueryOptions(
-  params: { distributorId: string; cluster?: ICluster; fetchFn?: typeof fetch },
-  options?: AirdropFeeQueryOptionsOverrides,
-) {
-  const { staleTimeMs = 60_000, gcTimeMs = 300_000, retry = 2, refetchOnWindowFocus = false } = options ?? {};
-  const cluster = params.cluster ?? ICluster.Mainnet;
-  const key = ["sf", "airdrop", "fee", cluster, params.distributorId];
-  return {
-    queryKey: key,
-    queryFn: () => fetchAirdropFee(params.distributorId, cluster, params.fetchFn ?? fetch),
-    staleTime: staleTimeMs,
-    gcTime: gcTimeMs,
-    retry,
-    refetchOnWindowFocus,
-  };
-}
-

--- a/packages/distributor/solana/fetchAirdropFee.ts
+++ b/packages/distributor/solana/fetchAirdropFee.ts
@@ -1,0 +1,61 @@
+export type AirdropFeeResponse = {
+  claimFee: string | number;
+  claimFeeDynamic?: {
+    minPrice: string;
+    maxPrice: string;
+    allocationFactor: string;
+  };
+  isCustom: boolean;
+};
+
+import { ICluster } from "@streamflow/common";
+
+export const fetchAirdropFee = async (
+  distributorId: string,
+  cluster: ICluster = ICluster.Mainnet,
+  fetchFn: typeof fetch = fetch,
+): Promise<AirdropFeeResponse> => {
+  const baseUrl = cluster === ICluster.Mainnet ? "https://api.streamflow.finance" : "https://staging-api.streamflow.finance";
+  const url = `${baseUrl}/v2/api/airdrops/${encodeURIComponent(distributorId)}/fees`;
+
+  const res = await fetchFn(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Airdrop fee API error: ${res.status} ${res.statusText}${text ? ` - ${text}` : ""}`);
+  }
+
+  const json = (await res.json()) as AirdropFeeResponse;
+  return json;
+};
+
+export interface AirdropFeeQueryOptionsOverrides {
+  staleTimeMs?: number;
+  gcTimeMs?: number;
+  retry?: number | boolean;
+  refetchOnWindowFocus?: boolean;
+}
+
+export function getAirdropFeeQueryOptions(
+  params: { distributorId: string; cluster?: ICluster; fetchFn?: typeof fetch },
+  options?: AirdropFeeQueryOptionsOverrides,
+) {
+  const { staleTimeMs = 60_000, gcTimeMs = 300_000, retry = 2, refetchOnWindowFocus = false } = options ?? {};
+  const cluster = params.cluster ?? ICluster.Mainnet;
+  const key = ["sf", "airdrop", "fee", cluster, params.distributorId];
+  return {
+    queryKey: key,
+    queryFn: () => fetchAirdropFee(params.distributorId, cluster, params.fetchFn ?? fetch),
+    staleTime: staleTimeMs,
+    gcTime: gcTimeMs,
+    retry,
+    refetchOnWindowFocus,
+  };
+}
+
+

--- a/packages/distributor/solana/fetchAirdropFee.ts
+++ b/packages/distributor/solana/fetchAirdropFee.ts
@@ -15,7 +15,7 @@ export interface AirdropFeeQueryOptionsOverrides {
   gcTimeMs?: number;
   retry?: number | boolean;
   refetchOnWindowFocus?: boolean;
-}
+}   
 
 export const fetchAirdropFee = async (
   distributorId: string,

--- a/packages/distributor/solana/index.ts
+++ b/packages/distributor/solana/index.ts
@@ -11,3 +11,5 @@ export * from "./utils.js";
 export * from "./types.js";
 
 export * as constants from "./constants.js";
+
+export * from "./fetchAirdropFee.js";

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -102,6 +102,7 @@ export interface IClaimData {
 
   amountUnlocked: BN;
   amountLocked: BN;
+  claimableAmount: BN;
   proof: Array<Array<number>>;
 }
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "8.9.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
Migrating Dynamic airdrop fees from app to the SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements dynamic airdrop claim fees resolved via backend fee params and token/SOL prices, adds token price fetching and bigint math utilities, updates types/exports, and bumps packages to v9.0.0.
> 
> - **Distributor (Solana)**:
>   - **Dynamic claim fee resolution**: Compute lamport fee via `resolveAirdropFeeLamportsUsingApi` using `fetchAirdropFee`, `fetchTokenPrice`, and price-based calculators with min/max clamping and fallbacks; default to minimum on errors.
>   - **BaseDistributorClient**: Store `cluster`; during `prepareClaimInstructions` derive `claimableAmount` (with legacy fallback), fetch mint, resolve fee, and pass to `prepareClaimFeeInstruction`.
>   - **New modules**: `solana/fees.ts` (fee constants, calculators, conversions) and `solana/fetchAirdropFee.ts`; re-export `fetchAirdropFee` in `solana/index.ts`.
>   - **Types**: `IClaimData` now includes `claimableAmount`.
> - **Common**:
>   - **New token price util**: `lib/fetch-token-price.ts` + export in `index.ts`.
>   - **Math util**: `multiplyBigIntByNumber` added to `lib/utils.ts`.
> - **Repo**:
>   - Version bump to `9.0.0` across packages and `lerna.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791571f97674b64ff7d03f4fce091122b0b297c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->