### PR TITLE
Export airdrop fees

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "9.0.0",
+  "version": "9.0.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/solana/index.ts
+++ b/packages/distributor/solana/index.ts
@@ -13,3 +13,5 @@ export * from "./types.js";
 export * as constants from "./constants.js";
 
 export * from "./fetchAirdropFee.js";
+
+export * from "./fees.js";

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exports the `fees` API from the Solana distributor entrypoint and bumps all package versions to 9.0.1.
> 
> - **Distributor (Solana)**:
>   - Export `fees` module via `packages/distributor/solana/index.ts` (`export * from "./fees.js"`).
> - **Release**:
>   - Bump versions to `9.0.1` in `lerna.json` and affected `package.json` files (`common`, `distributor`, `eslint-config`, `launchpad`, `staking`, `stream`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec9345caac62591e94a896276bf3c76d3f57d614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->