### PR TITLE
fix(ci): mitigate template injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/gh-alpha-release.yml
+++ b/.github/workflows/gh-alpha-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number (for manual runs)'
+        description: "PR number (for manual runs)"
         required: true
   pull_request:
     branches:
@@ -23,22 +23,27 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
       - name: Resolve alpha version
         id: set_alpha_version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
         run: |
           BASE_VERSION=$(node -p 'require("./lerna.json").version')
           SHORT_SHA=$(git rev-parse --short HEAD)
           ALPHA_VERSION=""
           PR_NUMBER=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="${{ github.head_ref }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
             if [[ "$BRANCH" == alpha/* ]]; then
               message=$(git log -1 --pretty=%B | head -n 1)
               if [[ "$message" != *'[skip alpha]'* ]]; then
-                PR_NUMBER="${{ github.event.pull_request.number }}"
+                PR_NUMBER="$PR_NUM"
                 ALPHA_VERSION="${BASE_VERSION}-alpha.p${PR_NUMBER}.${SHORT_SHA}"
               fi
             fi
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
             if [ -n "$PR_NUMBER" ]; then
               ALPHA_VERSION="${BASE_VERSION}-alpha.p${PR_NUMBER}.${SHORT_SHA}"
             fi
@@ -78,15 +83,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Version all packages
-        run: pnpm version-all ${{ needs.resolve-alpha.outputs.alpha_version }} -y
+        env:
+          ALPHA_VERSION: ${{ needs.resolve-alpha.outputs.alpha_version }}
+        run: pnpm version-all "$ALPHA_VERSION" -y
       - name: Git status
         run: git status
       - name: Commit version changes
+        env:
+          ALPHA_VERSION: ${{ needs.resolve-alpha.outputs.alpha_version }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
-          git commit -m "chore: version bump to ${{ needs.resolve-alpha.outputs.alpha_version }} [skip ci]" --no-verify || echo "No changes to commit"
+          git commit -m "chore: version bump to $ALPHA_VERSION [skip ci]" --no-verify || echo "No changes to commit"
       - name: Git status after
         run: git status
       - name: Build packages

--- a/.github/workflows/gh-publish.yml
+++ b/.github/workflows/gh-publish.yml
@@ -106,13 +106,17 @@ jobs:
             ${{ github.event.pull_request.body }}
           draft: false
           prerelease: false
-      - uses: actions/github-script@v4
+      - name: Comment release URL
+        uses: actions/github-script@v4
+        env:
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/v${{ env.CURRENT_VERSION }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const releaseUrl = process.env.RELEASE_URL;
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'https://github.com/${{ github.repository }}/releases/tag/v${{ env.CURRENT_VERSION }} is released 🎉'
+              body: `${releaseUrl} is released 🎉`
             })


### PR DESCRIPTION
## Summary

Fixes template injection vulnerabilities in GitHub Actions workflows identified by [Aikido security scan](https://app.aikido.dev/issues/26479874/detail).

GitHub Actions `run:` blocks that directly embed `${{ }}` template expressions referencing untrusted inputs (branch names, PR numbers, workflow dispatch params) are vulnerable to script injection. An attacker can craft a malicious branch name or PR body containing shell metacharacters that get evaluated by bash when the workflow runs.

### Vulnerabilities Fixed

**`.github/workflows/gh-alpha-release.yml`** (6 injection points):
- `${{ github.event_name }}` — used in `if` comparisons in shell
- `${{ github.head_ref }}` — attacker-controlled branch name injected directly
- `${{ github.event.pull_request.number }}` — injected into shell variable
- `${{ github.event.inputs.pr_number }}` — user-supplied workflow dispatch input
- `${{ needs.resolve-alpha.outputs.alpha_version }}` — injected into `pnpm version-all` arg and `git commit -m`

**`.github/workflows/gh-publish.yml`** (1 injection point):
- `${{ github.repository }}` — injected into `github-script` template literal

### Fix

All `${{ }}` expressions inside `run:` and `script:` blocks are moved to `env:` mappings, then referenced as shell environment variables (`$VAR`). Environment variable assignment treats values as literal strings, preventing shell metacharacter evaluation.

### Test plan

- [ ] Verify YAML syntax is valid (confirmed via `ruby -ryaml`)
- [ ] Confirm no `${{ }}` expressions remain in any `run:` blocks across both files
- [ ] Trigger the alpha release workflow on a branch prefixed `alpha/*` and verify it resolves the version correctly
- [ ] Merge a PR to `master` and verify the publish workflow creates the release and comment as expected