### PR TITLE
feat: bump distributor idls, support clawbackReques

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "11.5.0",
+  "version": "12.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "11.4.0",
+  "version": "11.5.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/distributor/solana/clients/BaseDistributorClient.ts
+++ b/packages/distributor/solana/clients/BaseDistributorClient.ts
@@ -55,7 +55,9 @@ import type {
   IGetClaimData,
   IGetDistributors,
   IInteractExt,
+  IRequestClawbackData,
   ISearchDistributors,
+  IWithdrawClawbackRequestData,
   ClawbackAccounts,
   NewDistributorAccounts,
   Fees,
@@ -521,7 +523,7 @@ export default abstract class BaseDistributorClient {
       distributor: distributorPublicKey,
       from: distributor.tokenVault,
       to: distributor.clawbackReceiver,
-      admin: extParams.invoker.publicKey,
+      authority: extParams.invoker.publicKey,
       mint: distributor.mint,
       tokenProgram: tokenProgramId,
     };
@@ -555,6 +557,114 @@ export default abstract class BaseDistributorClient {
     );
 
     return { ixs, txId: signature };
+  }
+
+  /**
+   * Requests delayed clawback by the configured fee partner authority.
+   * Once the request is recorded on-chain, clawback can be executed after the
+   * configured delay elapses.
+   */
+  public async requestClawback(
+    data: IRequestClawbackData,
+    extParams: IInteractExt,
+  ): Promise<ITransactionResult> {
+    const executionParams = this.unwrapExecutionParams(extParams);
+    const invoker = executionParams.invoker.publicKey;
+    invariant(invoker, "Invoker's PublicKey is not available, check passed wallet adapter!");
+    const ixs = await createAndEstimateTransaction(
+      (params) => this.prepareRequestClawbackInstructions(data, params),
+      executionParams,
+    );
+    const { tx, hash, context } = await prepareTransaction(this.connection, ixs, invoker);
+    const signature = await wrappedSignAndExecuteTransaction(
+      this.connection,
+      executionParams.invoker,
+      tx,
+      {
+        hash,
+        context,
+        commitment: this.getCommitment(),
+      },
+      { sendThrottler: this.sendThrottler, skipSimulation: executionParams.skipSimulation },
+    );
+
+    return { ixs, txId: signature };
+  }
+
+  public async prepareRequestClawbackInstructions(
+    data: IRequestClawbackData,
+    extParams: ITransactionExtResolved<IInteractExt>,
+  ): Promise<TransactionInstruction[]> {
+    if (!extParams.invoker.publicKey) {
+      throw new Error("Invoker's PublicKey is not available, check passed wallet adapter!");
+    }
+
+    const ixs: TransactionInstruction[] = prepareBaseInstructions(this.connection, extParams);
+
+    ixs.push(
+      await this.merkleDistributorProgram.methods
+        .requestClawback()
+        .accounts({
+          distributor: new PublicKey(data.id),
+          authority: extParams.invoker.publicKey,
+        })
+        .instruction(),
+    );
+
+    return ixs;
+  }
+
+  /**
+   * Withdraws a previously submitted clawback request, cancelling the delayed clawback flow.
+   */
+  public async withdrawClawbackRequest(
+    data: IWithdrawClawbackRequestData,
+    extParams: IInteractExt,
+  ): Promise<ITransactionResult> {
+    const executionParams = this.unwrapExecutionParams(extParams);
+    const invoker = executionParams.invoker.publicKey;
+    invariant(invoker, "Invoker's PublicKey is not available, check passed wallet adapter!");
+    const ixs = await createAndEstimateTransaction(
+      (params) => this.prepareWithdrawClawbackRequestInstructions(data, params),
+      executionParams,
+    );
+    const { tx, hash, context } = await prepareTransaction(this.connection, ixs, invoker);
+    const signature = await wrappedSignAndExecuteTransaction(
+      this.connection,
+      executionParams.invoker,
+      tx,
+      {
+        hash,
+        context,
+        commitment: this.getCommitment(),
+      },
+      { sendThrottler: this.sendThrottler, skipSimulation: executionParams.skipSimulation },
+    );
+
+    return { ixs, txId: signature };
+  }
+
+  public async prepareWithdrawClawbackRequestInstructions(
+    data: IWithdrawClawbackRequestData,
+    extParams: ITransactionExtResolved<IInteractExt>,
+  ): Promise<TransactionInstruction[]> {
+    if (!extParams.invoker.publicKey) {
+      throw new Error("Invoker's PublicKey is not available, check passed wallet adapter!");
+    }
+
+    const ixs: TransactionInstruction[] = prepareBaseInstructions(this.connection, extParams);
+
+    ixs.push(
+      await this.merkleDistributorProgram.methods
+        .withdrawClawbackRequest()
+        .accounts({
+          distributor: new PublicKey(data.id),
+          authority: extParams.invoker.publicKey,
+        })
+        .instruction(),
+    );
+
+    return ixs;
   }
 
   public async getClaim(claimStatus: string | PublicKey): Promise<AnyClaimStatus | null> {

--- a/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
@@ -87,7 +87,7 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
       ? new PublicKey(data.oracleAddress)
       : getTestOraclePda(this.alignedProxyProgram.programId, pk(mint), pk(admin));
 
-    return this.alignedProxyProgram.methods
+    let builder = this.alignedProxyProgram.methods
       .newDistributor({
         claimsClosable: data.claimsClosableByAdmin,
         version: new BN(data.version),
@@ -109,12 +109,19 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
         tokenProgram,
         priceOracle: oracle,
       })
-      .accountsPartial({ partnerOracle: this.partnerOracleProgramId, partnerOracleConfig: this.feeConfigPublicKey })
-      .instruction();
+      .accountsPartial({ partnerOracle: this.partnerOracleProgramId, partnerOracleConfig: this.feeConfigPublicKey });
+
+    if (data.partnerLink) {
+      builder = builder.remainingAccounts([
+        { pubkey: new PublicKey(data.partnerLink.address), isSigner: data.partnerLink.isSigner, isWritable: false },
+      ])
+    }
+
+    return builder.instruction();
   }
 
   protected async getClawbackInstruction(accounts: ClawbackAccounts): Promise<TransactionInstruction> {
-    const { distributor, from, to, mint, tokenProgram, admin } = accounts;
+    const { distributor, from, to, mint, tokenProgram, authority } = accounts;
     const alignedDistributorKey = getAlignedDistributorPda(
       this.alignedProxyProgram.programId,
       pk(accounts.distributor),
@@ -126,7 +133,7 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
     return this.alignedProxyProgram.methods
       .clawback()
       .accounts({
-        admin,
+        admin: authority,
         distributor,
         from,
         to,

--- a/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaAlignedDistributorClient.ts
@@ -114,7 +114,7 @@ export default class SolanaAlignedDistributorClient extends BaseDistributorClien
     if (data.partnerLink) {
       builder = builder.remainingAccounts([
         { pubkey: new PublicKey(data.partnerLink.address), isSigner: data.partnerLink.isSigner, isWritable: false },
-      ])
+      ]);
     }
 
     return builder.instruction();

--- a/packages/distributor/solana/clients/SolanaDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaDistributorClient.ts
@@ -33,7 +33,7 @@ export default class SolanaDistributorClient extends BaseDistributorClient {
     if (data.partnerLink) {
       builder = builder.remainingAccounts([
         { pubkey: new PublicKey(data.partnerLink.address), isSigner: data.partnerLink.isSigner, isWritable: false },
-      ])
+      ]);
     }
 
     return builder.instruction();

--- a/packages/distributor/solana/clients/SolanaDistributorClient.ts
+++ b/packages/distributor/solana/clients/SolanaDistributorClient.ts
@@ -1,4 +1,4 @@
-import { type TransactionInstruction } from "@solana/web3.js";
+import { PublicKey, type TransactionInstruction } from "@solana/web3.js";
 import BN from "bn.js";
 
 import { type ICreateDistributorData, type NewDistributorAccounts, type ClawbackAccounts } from "../types.js";
@@ -10,7 +10,7 @@ export default class SolanaDistributorClient extends BaseDistributorClient {
     accounts: Required<NewDistributorAccounts>,
   ): Promise<TransactionInstruction> {
     this.validateDistributorArgs(data);
-    return this.merkleDistributorProgram.methods
+    let builder = this.merkleDistributorProgram.methods
       .newDistributor(
         new BN(data.version),
         data.root,
@@ -28,8 +28,15 @@ export default class SolanaDistributorClient extends BaseDistributorClient {
         data.claimsLimit ?? null,
       )
       .accounts(accounts)
-      .accountsPartial({ partnerOracle: this.partnerOracleProgramId, partnerOracleConfig: this.feeConfigPublicKey })
-      .instruction();
+      .accountsPartial({ partnerOracle: this.partnerOracleProgramId, partnerOracleConfig: this.feeConfigPublicKey });
+
+    if (data.partnerLink) {
+      builder = builder.remainingAccounts([
+        { pubkey: new PublicKey(data.partnerLink.address), isSigner: data.partnerLink.isSigner, isWritable: false },
+      ])
+    }
+
+    return builder.instruction();
   }
 
   protected async getClawbackInstruction(accounts: ClawbackAccounts): Promise<TransactionInstruction> {

--- a/packages/distributor/solana/descriptor/aligned_distributor.ts
+++ b/packages/distributor/solana/descriptor/aligned_distributor.ts
@@ -8,7 +8,7 @@ export type AlignedDistributor = {
   "address": "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
   "metadata": {
     "name": "alignedDistributor",
-    "version": "2.0.0",
+    "version": "1.9.0",
     "spec": "0.1.0",
     "description": "Proxy for merkle distributor that updates Vesting duration according to token market performance."
   },
@@ -160,9 +160,9 @@ export type AlignedDistributor = {
         {
           "name": "admin",
           "docs": [
-            "Only Admin can trigger the clawback of funds",
+            "Admin or anybody in case distributor has been clawed back (usually by clawback authority).",
+            "Since receiver is set by the admin, it's generally safe to call clawback by anyone here if the merkle distributor has been clawed back",
           ],
-          "writable": true,
           "signer": true
         },
         {
@@ -1038,6 +1038,16 @@ export type AlignedDistributor = {
       "name": "noFeesToClaim",
       "msg": "No fees to claim"
     },
+    {
+      "code": 6015,
+      "name": "durationNotUpdated",
+      "msg": "Update won't lead to any changes in unlock schedule"
+    },
+    {
+      "code": 6016,
+      "name": "clawbackAlreadyClaimed",
+      "msg": "Clawback already claimed"
+    },
   ],
   "types": [
     {
@@ -1525,14 +1535,56 @@ export type AlignedDistributor = {
             "type": "u8"
           },
           {
-            "name": "buffer",
+            "name": "autoClaim",
             "docs": [
-              "Buffer for additional fields",
+              "Whether Distributor supports auto-claim",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "alignBuffer1",
+            "docs": [
+              "Extra buffer to keep alignment, may be reused",
             ],
             "type": {
               "array": [
                 "u8",
-                13,
+                4,
+              ]
+            }
+          },
+          {
+            "name": "feePartner",
+            "docs": [
+              "Partner wallet whose fee schedule was applied, if different from the creator",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "clawbackRequestTs",
+            "docs": [
+              "Timestamp when clawback was requested by the fee partner",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer1",
+            "docs": [
+              "Buffers for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32,
+              ]
+            }
+          },
+          {
+            "name": "buffer2",
+            "type": {
+              "array": [
+                "u8",
+                32,
               ]
             }
           },

--- a/packages/distributor/solana/descriptor/idl/aligned_distributor.json
+++ b/packages/distributor/solana/descriptor/idl/aligned_distributor.json
@@ -2,7 +2,7 @@
   "address": "aMERKpFAWoChCi5oZwPvgsSCoGpZKBiU7fi76bdZjt2",
   "metadata": {
     "name": "aligned_distributor",
-    "version": "2.0.0",
+    "version": "1.9.0",
     "spec": "0.1.0",
     "description": "Proxy for merkle distributor that updates Vesting duration according to token market performance."
   },
@@ -154,9 +154,9 @@
         {
           "name": "admin",
           "docs": [
-            "Only Admin can trigger the clawback of funds"
+            "Admin or anybody in case distributor has been clawed back (usually by clawback authority).",
+            "Since receiver is set by the admin, it's generally safe to call clawback by anyone here if the merkle distributor has been clawed back"
           ],
-          "writable": true,
           "signer": true
         },
         {
@@ -1031,6 +1031,16 @@
       "code": 6014,
       "name": "NoFeesToClaim",
       "msg": "No fees to claim"
+    },
+    {
+      "code": 6015,
+      "name": "DurationNotUpdated",
+      "msg": "Update won't lead to any changes in unlock schedule"
+    },
+    {
+      "code": 6016,
+      "name": "ClawbackAlreadyClaimed",
+      "msg": "Clawback already claimed"
     }
   ],
   "types": [
@@ -1519,14 +1529,56 @@
             "type": "u8"
           },
           {
-            "name": "buffer",
+            "name": "auto_claim",
             "docs": [
-              "Buffer for additional fields"
+              "Whether Distributor supports auto-claim"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "align_buffer_1",
+            "docs": [
+              "Extra buffer to keep alignment, may be reused"
             ],
             "type": {
               "array": [
                 "u8",
-                13
+                4
+              ]
+            }
+          },
+          {
+            "name": "fee_partner",
+            "docs": [
+              "Partner wallet whose fee schedule was applied, if different from the creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "clawback_request_ts",
+            "docs": [
+              "Timestamp when clawback was requested by the fee partner"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer_1",
+            "docs": [
+              "Buffers for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "buffer_2",
+            "type": {
+              "array": [
+                "u8",
+                32
               ]
             }
           }

--- a/packages/distributor/solana/descriptor/idl/merkle_distributor.json
+++ b/packages/distributor/solana/descriptor/idl/merkle_distributor.json
@@ -2,7 +2,7 @@
   "address": "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N",
   "metadata": {
     "name": "merkle_distributor",
-    "version": "2.0.0",
+    "version": "1.9.0",
     "spec": "0.1.0",
     "description": "A Solana program for distributing tokens according to a Merkle root.",
     "repository": "https://github.com/streamflow-finance/distributor"
@@ -595,15 +595,109 @@
           "writable": true
         },
         {
-          "name": "admin",
+          "name": "authority",
           "docs": [
-            "Only Admin can trigger the clawback of funds"
+            "Signer that authorizes the clawback execution."
           ],
           "writable": true,
           "signer": true
         },
         {
           "name": "mint"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "The [System] program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL [Token] program."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "clawback_v2",
+      "discriminator": [
+        21,
+        210,
+        60,
+        179,
+        193,
+        134,
+        82,
+        155
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor]."
+          ],
+          "writable": true
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Distributor ATA containing the tokens to distribute."
+          ],
+          "writable": true
+        },
+        {
+          "name": "to",
+          "docs": [
+            "The Clawback token account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "even when the caller is `CANCEL_AUTHORITY`."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Signer that authorizes the clawback execution."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "auto_claim_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  65,
+                  117,
+                  116,
+                  111,
+                  67,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              }
+            ]
+          }
         },
         {
           "name": "system_program",
@@ -1040,6 +1134,232 @@
       ]
     },
     {
+      "name": "new_claim_by_worker",
+      "discriminator": [
+        181,
+        133,
+        223,
+        117,
+        188,
+        131,
+        243,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor]."
+          ],
+          "writable": true,
+          "relations": [
+            "auto_claim_state"
+          ]
+        },
+        {
+          "name": "auto_claim_state",
+          "docs": [
+            "Auto-claim SOL reserve for the distributor."
+          ],
+          "writable": true
+        },
+        {
+          "name": "claim_status",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  108,
+                  97,
+                  105,
+                  109,
+                  83,
+                  116,
+                  97,
+                  116,
+                  117,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "claimant"
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Distributor ATA containing the tokens to distribute."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "distributor.mint",
+                "account": "MerkleDistributor"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "claimant"
+        },
+        {
+          "name": "admin",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Worker account, anyone can execute the instruction since distribution is validated by the protocol"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim."
+          ],
+          "relations": [
+            "distributor"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "The [Associated Token] program."
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL [Token] program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "The [System] program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_unlocked",
+          "type": "u64"
+        },
+        {
+          "name": "amount_locked",
+          "type": "u64"
+        },
+        {
+          "name": "proof",
+          "type": {
+            "vec": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "new_distributor",
       "docs": [
         "READ THE FOLLOWING:",
@@ -1361,6 +1681,398 @@
       ]
     },
     {
+      "name": "new_distributor_v2",
+      "discriminator": [
+        45,
+        79,
+        3,
+        238,
+        185,
+        37,
+        253,
+        179
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "[MerkleDistributor]."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  77,
+                  101,
+                  114,
+                  107,
+                  108,
+                  101,
+                  68,
+                  105,
+                  115,
+                  116,
+                  114,
+                  105,
+                  98,
+                  117,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "arg",
+                "path": "version"
+              }
+            ]
+          }
+        },
+        {
+          "name": "clawback_receiver",
+          "docs": [
+            "Clawback receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to distribute."
+          ]
+        },
+        {
+          "name": "token_vault",
+          "docs": [
+            "Token vault"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "Admin wallet, responsible for creating the distributor and paying for the transaction.",
+            "Also has the authority to set the clawback receiver and change itself."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "auto_claim_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  65,
+                  117,
+                  116,
+                  111,
+                  67,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "The [System] program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "The [Associated Token] program."
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The [Token] program."
+          ]
+        },
+        {
+          "name": "partner_oracle_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  105,
+                  114,
+                  100,
+                  114,
+                  111,
+                  112,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                12,
+                48,
+                148,
+                48,
+                221,
+                89,
+                2,
+                209,
+                180,
+                126,
+                151,
+                216,
+                166,
+                3,
+                112,
+                50,
+                177,
+                192,
+                141,
+                218,
+                37,
+                78,
+                51,
+                109,
+                243,
+                106,
+                174,
+                122,
+                93,
+                121,
+                191,
+                119
+              ]
+            }
+          }
+        },
+        {
+          "name": "partner_oracle",
+          "docs": [
+            "Partner Oracle program that stores fees"
+          ],
+          "address": "pardpVtPjC8nLj1Dwncew62mUzfChdCX1EaoZe8oCAa"
+        }
+      ],
+      "args": [
+        {
+          "name": "version",
+          "type": "u64"
+        },
+        {
+          "name": "root",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "max_total_claim",
+          "type": "u64"
+        },
+        {
+          "name": "total_amount_unlocked",
+          "type": "u64"
+        },
+        {
+          "name": "total_amount_locked",
+          "type": "u64"
+        },
+        {
+          "name": "max_num_nodes",
+          "type": "u64"
+        },
+        {
+          "name": "unlock_period",
+          "type": "u64"
+        },
+        {
+          "name": "start_vesting_ts",
+          "type": "u64"
+        },
+        {
+          "name": "end_vesting_ts",
+          "type": "u64"
+        },
+        {
+          "name": "clawback_start_ts",
+          "type": "u64"
+        },
+        {
+          "name": "claims_closable_by_admin",
+          "type": "bool"
+        },
+        {
+          "name": "claims_closable_by_claimant",
+          "type": "bool"
+        },
+        {
+          "name": "can_update_duration",
+          "type": "bool"
+        },
+        {
+          "name": "claims_limit",
+          "type": "u16"
+        },
+        {
+          "name": "auto_claim",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "realloc_distributor",
+      "discriminator": [
+        167,
+        165,
+        22,
+        244,
+        248,
+        99,
+        33,
+        42
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "distributor",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  77,
+                  101,
+                  114,
+                  107,
+                  108,
+                  101,
+                  68,
+                  105,
+                  115,
+                  116,
+                  114,
+                  105,
+                  98,
+                  117,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "arg",
+                "path": "version"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "version",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "refund_claim",
       "discriminator": [
         157,
@@ -1434,6 +2146,36 @@
             "The [System] program."
           ],
           "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "request_clawback",
+      "discriminator": [
+        57,
+        57,
+        31,
+        191,
+        239,
+        66,
+        54,
+        8
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor]."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Fee partner signer that may initiate the delayed clawback flow."
+          ],
+          "signer": true
         }
       ],
       "args": []
@@ -1594,9 +2336,52 @@
           }
         }
       ]
+    },
+    {
+      "name": "withdraw_clawback_request",
+      "discriminator": [
+        149,
+        159,
+        253,
+        249,
+        226,
+        250,
+        21,
+        8
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor]."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Fee partner signer that may initiate the delayed clawback flow."
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
+    {
+      "name": "AutoClaimState",
+      "discriminator": [
+        216,
+        43,
+        239,
+        75,
+        58,
+        129,
+        132,
+        12
+      ]
+    },
     {
       "name": "ClaimStatus",
       "discriminator": [
@@ -1813,9 +2598,142 @@
       "code": 6026,
       "name": "NoFeesToClaim",
       "msg": "No fees to claim"
+    },
+    {
+      "code": 6027,
+      "name": "AutoClaimNotPossible",
+      "msg": "Auto-claim is available only for instant airdrops"
+    },
+    {
+      "code": 6028,
+      "name": "AutoClaimEnabled",
+      "msg": "Auto-claim is enabled for this airdrop, manual claims are not possible, clawback v2 is required"
+    },
+    {
+      "code": 6029,
+      "name": "AutoClaimNotEnabled",
+      "msg": "Auto-claim is not enabled for this airdrop"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidAutoClaimTokenAccount",
+      "msg": "Invalid auto-claim recipient token account"
+    },
+    {
+      "code": 6031,
+      "name": "ClawbackRequestAlreadyRequested",
+      "msg": "Clawback has already been requested"
+    },
+    {
+      "code": 6032,
+      "name": "ClawbackRequestNotRequested",
+      "msg": "Clawback has not been requested"
+    },
+    {
+      "code": 6033,
+      "name": "ClawbackRequestDelayPending",
+      "msg": "Clawback request delay has not passed yet"
     }
   ],
   "types": [
+    {
+      "name": "AutoClaimState",
+      "docs": [
+        "Tracks reserved and spent SOL for worker auto-claims."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "distributor",
+            "docs": [
+              "Distributor account this state belongs to."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tx_fee_lamports",
+            "docs": [
+              "Fixed reimbursement for transaction processing."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ata_rent_lamports",
+            "docs": [
+              "Fixed reimbursement for ATA creation when it is needed."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "claim_status_rent_lamports",
+            "docs": [
+              "Fixed reimbursement tom cover ClaimStatus account creation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_funded",
+            "docs": [
+              "Total SOL funded for reimbursements."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_spent",
+            "docs": [
+              "Total SOL reimbursed so far."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "claims_processed",
+            "docs": [
+              "Number of claims processed by the worker."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ata_creations",
+            "docs": [
+              "Number of ATAs funded by the worker path."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer1",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "buffer2",
+            "docs": [
+              "Buffer for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "ClaimClosedEvent",
       "docs": [
@@ -2237,14 +3155,56 @@
             "type": "u8"
           },
           {
-            "name": "buffer",
+            "name": "auto_claim",
             "docs": [
-              "Buffer for additional fields"
+              "Whether Distributor supports auto-claim"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "align_buffer_1",
+            "docs": [
+              "Extra buffer to keep alignment, may be reused"
             ],
             "type": {
               "array": [
                 "u8",
-                13
+                4
+              ]
+            }
+          },
+          {
+            "name": "fee_partner",
+            "docs": [
+              "Partner wallet whose fee schedule was applied, if different from the creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "clawback_request_ts",
+            "docs": [
+              "Timestamp when clawback was requested by the fee partner"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer_1",
+            "docs": [
+              "Buffers for additional fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "buffer_2",
+            "type": {
+              "array": [
+                "u8",
+                32
               ]
             }
           }

--- a/packages/distributor/solana/descriptor/merkle_distributor.ts
+++ b/packages/distributor/solana/descriptor/merkle_distributor.ts
@@ -8,7 +8,7 @@ export type MerkleDistributor = {
   "address": "MErKy6nZVoVAkryxAejJz2juifQ4ArgLgHmaJCQkU7N",
   "metadata": {
     "name": "merkleDistributor",
-    "version": "2.0.0",
+    "version": "1.9.0",
     "spec": "0.1.0",
     "description": "A Solana program for distributing tokens according to a Merkle root.",
     "repository": "https://github.com/streamflow-finance/distributor"
@@ -601,15 +601,109 @@ export type MerkleDistributor = {
           "writable": true
         },
         {
-          "name": "admin",
+          "name": "authority",
           "docs": [
-            "Only Admin can trigger the clawback of funds",
+            "Signer that authorizes the clawback execution.",
           ],
           "writable": true,
           "signer": true
         },
         {
           "name": "mint"
+        },
+        {
+          "name": "systemProgram",
+          "docs": [
+            "The [System] program.",
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL [Token] program.",
+          ]
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "clawbackV2",
+      "discriminator": [
+        21,
+        210,
+        60,
+        179,
+        193,
+        134,
+        82,
+        155,
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor].",
+          ],
+          "writable": true
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Distributor ATA containing the tokens to distribute.",
+          ],
+          "writable": true
+        },
+        {
+          "name": "to",
+          "docs": [
+            "The Clawback token account.",
+          ],
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "even when the caller is `CANCEL_AUTHORITY`.",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Signer that authorizes the clawback execution.",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "autoClaimState",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  65,
+                  117,
+                  116,
+                  111,
+                  67,
+                  108,
+                  97,
+                  105,
+                  109,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+            ]
+          }
         },
         {
           "name": "systemProgram",
@@ -1046,6 +1140,232 @@ export type MerkleDistributor = {
       ]
     },
     {
+      "name": "newClaimByWorker",
+      "discriminator": [
+        181,
+        133,
+        223,
+        117,
+        188,
+        131,
+        243,
+        158,
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor].",
+          ],
+          "writable": true,
+          "relations": [
+            "autoClaimState",
+          ]
+        },
+        {
+          "name": "autoClaimState",
+          "docs": [
+            "Auto-claim SOL reserve for the distributor.",
+          ],
+          "writable": true
+        },
+        {
+          "name": "claimStatus",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  108,
+                  97,
+                  105,
+                  109,
+                  83,
+                  116,
+                  97,
+                  116,
+                  117,
+                  115,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "claimant"
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+            ]
+          }
+        },
+        {
+          "name": "from",
+          "docs": [
+            "Distributor ATA containing the tokens to distribute.",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProgram"
+              },
+              {
+                "kind": "account",
+                "path": "distributor.mint",
+                "account": "merkleDistributor"
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
+        },
+        {
+          "name": "to",
+          "writable": true
+        },
+        {
+          "name": "claimant"
+        },
+        {
+          "name": "admin",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Worker account, anyone can execute the instruction since distribution is validated by the protocol",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to claim.",
+          ],
+          "relations": [
+            "distributor",
+          ]
+        },
+        {
+          "name": "associatedTokenProgram",
+          "docs": [
+            "The [Associated Token] program.",
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL [Token] program.",
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "docs": [
+            "The [System] program.",
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "eventAuthority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121,
+                ]
+              },
+            ]
+          }
+        },
+        {
+          "name": "program"
+        },
+      ],
+      "args": [
+        {
+          "name": "amountUnlocked",
+          "type": "u64"
+        },
+        {
+          "name": "amountLocked",
+          "type": "u64"
+        },
+        {
+          "name": "proof",
+          "type": {
+            "vec": {
+              "array": [
+                "u8",
+                32,
+              ]
+            }
+          }
+        },
+      ]
+    },
+    {
       "name": "newDistributor",
       "docs": [
         "READ THE FOLLOWING:",
@@ -1367,6 +1687,398 @@ export type MerkleDistributor = {
       ]
     },
     {
+      "name": "newDistributorV2",
+      "discriminator": [
+        45,
+        79,
+        3,
+        238,
+        185,
+        37,
+        253,
+        179,
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "[MerkleDistributor].",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  77,
+                  101,
+                  114,
+                  107,
+                  108,
+                  101,
+                  68,
+                  105,
+                  115,
+                  116,
+                  114,
+                  105,
+                  98,
+                  117,
+                  116,
+                  111,
+                  114,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "arg",
+                "path": "version"
+              },
+            ]
+          }
+        },
+        {
+          "name": "clawbackReceiver",
+          "docs": [
+            "Clawback receiver token account",
+          ],
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The mint to distribute.",
+          ]
+        },
+        {
+          "name": "tokenVault",
+          "docs": [
+            "Token vault",
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+              {
+                "kind": "account",
+                "path": "tokenProgram"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "Admin wallet, responsible for creating the distributor and paying for the transaction.",
+            "Also has the authority to set the clawback receiver and change itself.",
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "autoClaimState",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  65,
+                  117,
+                  116,
+                  111,
+                  67,
+                  108,
+                  97,
+                  105,
+                  109,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "distributor"
+              },
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "docs": [
+            "The [System] program.",
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "associatedTokenProgram",
+          "docs": [
+            "The [Associated Token] program.",
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "The [Token] program.",
+          ]
+        },
+        {
+          "name": "partnerOracleConfig",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  105,
+                  114,
+                  100,
+                  114,
+                  111,
+                  112,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103,
+                ]
+              },
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                12,
+                48,
+                148,
+                48,
+                221,
+                89,
+                2,
+                209,
+                180,
+                126,
+                151,
+                216,
+                166,
+                3,
+                112,
+                50,
+                177,
+                192,
+                141,
+                218,
+                37,
+                78,
+                51,
+                109,
+                243,
+                106,
+                174,
+                122,
+                93,
+                121,
+                191,
+                119,
+              ]
+            }
+          }
+        },
+        {
+          "name": "partnerOracle",
+          "docs": [
+            "Partner Oracle program that stores fees",
+          ],
+          "address": "pardpVtPjC8nLj1Dwncew62mUzfChdCX1EaoZe8oCAa"
+        },
+      ],
+      "args": [
+        {
+          "name": "version",
+          "type": "u64"
+        },
+        {
+          "name": "root",
+          "type": {
+            "array": [
+              "u8",
+              32,
+            ]
+          }
+        },
+        {
+          "name": "maxTotalClaim",
+          "type": "u64"
+        },
+        {
+          "name": "totalAmountUnlocked",
+          "type": "u64"
+        },
+        {
+          "name": "totalAmountLocked",
+          "type": "u64"
+        },
+        {
+          "name": "maxNumNodes",
+          "type": "u64"
+        },
+        {
+          "name": "unlockPeriod",
+          "type": "u64"
+        },
+        {
+          "name": "startVestingTs",
+          "type": "u64"
+        },
+        {
+          "name": "endVestingTs",
+          "type": "u64"
+        },
+        {
+          "name": "clawbackStartTs",
+          "type": "u64"
+        },
+        {
+          "name": "claimsClosableByAdmin",
+          "type": "bool"
+        },
+        {
+          "name": "claimsClosableByClaimant",
+          "type": "bool"
+        },
+        {
+          "name": "canUpdateDuration",
+          "type": "bool"
+        },
+        {
+          "name": "claimsLimit",
+          "type": "u16"
+        },
+        {
+          "name": "autoClaim",
+          "type": "bool"
+        },
+      ]
+    },
+    {
+      "name": "reallocDistributor",
+      "discriminator": [
+        167,
+        165,
+        22,
+        244,
+        248,
+        99,
+        33,
+        42,
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "distributor",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  77,
+                  101,
+                  114,
+                  107,
+                  108,
+                  101,
+                  68,
+                  105,
+                  115,
+                  116,
+                  114,
+                  105,
+                  98,
+                  117,
+                  116,
+                  111,
+                  114,
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "arg",
+                "path": "version"
+              },
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": [
+        {
+          "name": "version",
+          "type": "u64"
+        },
+      ]
+    },
+    {
       "name": "refundClaim",
       "discriminator": [
         157,
@@ -1440,6 +2152,36 @@ export type MerkleDistributor = {
             "The [System] program.",
           ],
           "address": "11111111111111111111111111111111"
+        },
+      ],
+      "args": []
+    },
+    {
+      "name": "requestClawback",
+      "discriminator": [
+        57,
+        57,
+        31,
+        191,
+        239,
+        66,
+        54,
+        8,
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor].",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Fee partner signer that may initiate the delayed clawback flow.",
+          ],
+          "signer": true
         },
       ],
       "args": []
@@ -1601,8 +2343,51 @@ export type MerkleDistributor = {
         },
       ]
     },
+    {
+      "name": "withdrawClawbackRequest",
+      "discriminator": [
+        149,
+        159,
+        253,
+        249,
+        226,
+        250,
+        21,
+        8,
+      ],
+      "accounts": [
+        {
+          "name": "distributor",
+          "docs": [
+            "The [MerkleDistributor].",
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Fee partner signer that may initiate the delayed clawback flow.",
+          ],
+          "signer": true
+        },
+      ],
+      "args": []
+    },
   ],
   "accounts": [
+    {
+      "name": "autoClaimState",
+      "discriminator": [
+        216,
+        43,
+        239,
+        75,
+        58,
+        129,
+        132,
+        12,
+      ]
+    },
     {
       "name": "claimStatus",
       "discriminator": [
@@ -1820,8 +2605,141 @@ export type MerkleDistributor = {
       "name": "noFeesToClaim",
       "msg": "No fees to claim"
     },
+    {
+      "code": 6027,
+      "name": "autoClaimNotPossible",
+      "msg": "Auto-claim is available only for instant airdrops"
+    },
+    {
+      "code": 6028,
+      "name": "autoClaimEnabled",
+      "msg": "Auto-claim is enabled for this airdrop, manual claims are not possible, clawback v2 is required"
+    },
+    {
+      "code": 6029,
+      "name": "autoClaimNotEnabled",
+      "msg": "Auto-claim is not enabled for this airdrop"
+    },
+    {
+      "code": 6030,
+      "name": "invalidAutoClaimTokenAccount",
+      "msg": "Invalid auto-claim recipient token account"
+    },
+    {
+      "code": 6031,
+      "name": "clawbackRequestAlreadyRequested",
+      "msg": "Clawback has already been requested"
+    },
+    {
+      "code": 6032,
+      "name": "clawbackRequestNotRequested",
+      "msg": "Clawback has not been requested"
+    },
+    {
+      "code": 6033,
+      "name": "clawbackRequestDelayPending",
+      "msg": "Clawback request delay has not passed yet"
+    },
   ],
   "types": [
+    {
+      "name": "autoClaimState",
+      "docs": [
+        "Tracks reserved and spent SOL for worker auto-claims.",
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed.",
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "distributor",
+            "docs": [
+              "Distributor account this state belongs to.",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "txFeeLamports",
+            "docs": [
+              "Fixed reimbursement for transaction processing.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ataRentLamports",
+            "docs": [
+              "Fixed reimbursement for ATA creation when it is needed.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "claimStatusRentLamports",
+            "docs": [
+              "Fixed reimbursement tom cover ClaimStatus account creation.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalFunded",
+            "docs": [
+              "Total SOL funded for reimbursements.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalSpent",
+            "docs": [
+              "Total SOL reimbursed so far.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "claimsProcessed",
+            "docs": [
+              "Number of claims processed by the worker.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ataCreations",
+            "docs": [
+              "Number of ATAs funded by the worker path.",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer1",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32,
+              ]
+            }
+          },
+          {
+            "name": "buffer2",
+            "docs": [
+              "Buffer for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32,
+              ]
+            }
+          },
+        ]
+      }
+    },
     {
       "name": "claimClosedEvent",
       "docs": [
@@ -2243,14 +3161,56 @@ export type MerkleDistributor = {
             "type": "u8"
           },
           {
-            "name": "buffer",
+            "name": "autoClaim",
             "docs": [
-              "Buffer for additional fields",
+              "Whether Distributor supports auto-claim",
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "alignBuffer1",
+            "docs": [
+              "Extra buffer to keep alignment, may be reused",
             ],
             "type": {
               "array": [
                 "u8",
-                13,
+                4,
+              ]
+            }
+          },
+          {
+            "name": "feePartner",
+            "docs": [
+              "Partner wallet whose fee schedule was applied, if different from the creator",
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "clawbackRequestTs",
+            "docs": [
+              "Timestamp when clawback was requested by the fee partner",
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "buffer1",
+            "docs": [
+              "Buffers for additional fields",
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32,
+              ]
+            }
+          },
+          {
+            "name": "buffer2",
+            "type": {
+              "array": [
+                "u8",
+                32,
               ]
             }
           },

--- a/packages/distributor/solana/types.ts
+++ b/packages/distributor/solana/types.ts
@@ -38,6 +38,8 @@ export type ClaimLockedAccounts = IdlAccountsOfMethod<MerkleDistributorIDL, "cla
 export type ClawbackAccounts = IdlAccountsOfMethod<MerkleDistributorIDL, "clawback">;
 export type CloseClaimAccounts = IdlAccountsOfMethod<MerkleDistributorIDL, "closeClaim">;
 export type CloseClaimArgs = IdlInstruction<MerkleDistributorIDL, "closeClaim">["args"];
+export type RequestClawbackAccounts = IdlAccountsOfMethod<MerkleDistributorIDL, "requestClawback">;
+export type WithdrawClawbackRequestAccounts = IdlAccountsOfMethod<MerkleDistributorIDL, "withdrawClawbackRequest">;
 
 /**
  * @type
@@ -72,6 +74,8 @@ export interface ICreateDistributorData {
   claimsClosableByAdmin: boolean;
   claimsClosableByClaimant?: boolean;
   claimsLimit?: number;
+  // signer or PartnerLink PDA used for fee derivation
+  partnerLink?: { address: string; isSigner: boolean };
 }
 
 export interface AlignedDistributorData {
@@ -134,6 +138,10 @@ export interface ICloseClaimData extends Partial<Omit<IClaimData, "id">> {
 export interface IClawbackData {
   id: string;
 }
+
+export type IRequestClawbackData = IClawbackData;
+
+export type IWithdrawClawbackRequestData = IClawbackData;
 
 export interface IGetClaimData {
   id: string;

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
- feat: bump distributor IDLs, expose feePartner;
- feat: pass partnerLink in remaining accounts for custom fee derivation;
- feat: export clawbackRequest by feePartner;
- feat!: rename `admin` -> `authority` in clawback since the authority can differ from`admin`; the change does not break previous versions of the sdk since accounts are passed as vectors, it just changes how the account should be referred when calling with the anchor client;