### PR TITLE
chore: add minimumReleaseAge supply chain security setting

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "packages/*"
   - "examples/*"
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Intent

Add pnpm's `minimumReleaseAge` setting to mitigate supply chain attacks by preventing installation of packages published less than 7 days ago.

## Notable Changes

- `pnpm-workspace.yaml` — adds `minimumReleaseAge: 10080` (7 days in minutes) per [pnpm docs](https://pnpm.io/settings)

## How to Verify

1. Check `pnpm-workspace.yaml` contains `minimumReleaseAge: 10080`
2. Run `pnpm install` — packages published within the last 7 days should be rejected with an error
3. Optionally test with `minimumReleaseAgeExclude` for any packages that need to bypass the cooldown