### PR TITLE
fix: sdk audit fixes (#STRE-21, #STRE-13, #STRE-4)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "12.2.0",
+  "version": "12.2.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "command": {
     "run": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/common",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "Common utilities and types used by streamflow packages.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "type": "module",

--- a/packages/distributor/package.json
+++ b/packages/distributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/distributor",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "JavaScript SDK to interact with Streamflow Airdrop protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/eslint-config",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "ESLint configuration for Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "engines": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/launchpad",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "JavaScript SDK to interact with Streamflow Launchpad protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/staking",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "JavaScript SDK to interact with Streamflow Staking protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/__tests__/solana/streamClient.spec.ts
+++ b/packages/stream/__tests__/solana/streamClient.spec.ts
@@ -432,7 +432,7 @@ describe("SolanaStreamClient Transaction Builders", async () => {
       instruction: unknown,
       calls: ReadonlyArray<{ source: PublicKey; destination: unknown; owner: unknown }>,
     ) => {
-      calls.forEach(({ source, destination }, index) => {
+      calls.forEach(({ source, destination, owner }, index) => {
         expect(mockAddExtraAccountMetasForExecute).toHaveBeenNthCalledWith(
           index + 1,
           (instance as any).connection,
@@ -441,7 +441,7 @@ describe("SolanaStreamClient Transaction Builders", async () => {
           source,
           publicKeys.mint,
           destination,
-          source,
+          owner,
           1n,
           "confirmed",
         );
@@ -507,17 +507,17 @@ describe("SolanaStreamClient Transaction Builders", async () => {
           {
             source: decodedStream.escrowTokens,
             destination: decodedStream.recipientTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.streamflowTreasuryTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.partnerTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
         ]);
       });
@@ -540,22 +540,22 @@ describe("SolanaStreamClient Transaction Builders", async () => {
           {
             source: decodedStream.escrowTokens,
             destination: decodedStream.recipientTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.streamflowTreasuryTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.partnerTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: decodedStream.senderTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
         ]);
       });
@@ -652,22 +652,22 @@ describe("SolanaStreamClient Transaction Builders", async () => {
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.recipientTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.streamflowTreasuryTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.partnerTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: decodedStream.escrowTokens,
             destination: publicKeys.proxyTokens,
-            owner: publicKeys.stream,
+            owner: decodedStream.escrowTokens,
           },
           {
             source: publicKeys.proxyTokens,

--- a/packages/stream/__tests__/solana/streamClient.spec.ts
+++ b/packages/stream/__tests__/solana/streamClient.spec.ts
@@ -432,7 +432,7 @@ describe("SolanaStreamClient Transaction Builders", async () => {
       instruction: unknown,
       calls: ReadonlyArray<{ source: PublicKey; destination: unknown; owner: unknown }>,
     ) => {
-      calls.forEach(({ source, destination, owner }, index) => {
+      calls.forEach(({ source, destination }, index) => {
         expect(mockAddExtraAccountMetasForExecute).toHaveBeenNthCalledWith(
           index + 1,
           (instance as any).connection,
@@ -441,7 +441,7 @@ describe("SolanaStreamClient Transaction Builders", async () => {
           source,
           publicKeys.mint,
           destination,
-          owner,
+          source,
           1n,
           "confirmed",
         );

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamflow/stream",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "JavaScript SDK to interact with Streamflow protocol.",
   "homepage": "https://github.com/streamflow-finance/js-sdk/",
   "main": "./dist/cjs/index.cjs",

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -1723,7 +1723,9 @@ export class SolanaStreamClient {
     if (!escrow?.data) {
       throw new Error("Couldn't get account info");
     }
-    const { mint, partner, senderTokens, escrowTokens, partnerFeePercent, streamflowFeePercent } = decodeStream(escrow?.data);
+    const { mint, partner, senderTokens, escrowTokens, partnerFeePercent, streamflowFeePercent } = decodeStream(
+      escrow?.data,
+    );
 
     const { mint: mintAccount, tokenProgramId } = await getMintAndProgram(this.connection, mint);
     const streamflowTreasuryTokens = await ata(mint, STREAMFLOW_TREASURY_PUBLIC_KEY, tokenProgramId);

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -1304,9 +1304,9 @@ export class SolanaStreamClient {
       mintAccount,
       tokenProgramId,
       potentialTransfers: [
-        { source: escrowTokens, destination: recipientTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: partnerTokens, owner: streamPublicKey },
+        { source: escrowTokens, destination: recipientTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: partnerTokens, owner: escrowTokens },
       ],
     });
 
@@ -1418,10 +1418,10 @@ export class SolanaStreamClient {
       mintAccount,
       tokenProgramId,
       potentialTransfers: [
-        { source: escrowTokens, destination: recipientTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: partnerTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: proxyTokens, owner: streamPublicKey },
+        { source: escrowTokens, destination: recipientTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: partnerTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: proxyTokens, owner: escrowTokens },
         { source: proxyTokens, destination: senderTokens, owner: proxyMetadata },
       ],
     });
@@ -1486,10 +1486,10 @@ export class SolanaStreamClient {
       mintAccount,
       tokenProgramId,
       potentialTransfers: [
-        { source: escrowTokens, destination: recipientTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: partnerTokens, owner: streamPublicKey },
-        { source: escrowTokens, destination: senderTokens, owner: streamPublicKey },
+        { source: escrowTokens, destination: recipientTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: streamflowTreasuryTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: partnerTokens, owner: escrowTokens },
+        { source: escrowTokens, destination: senderTokens, owner: escrowTokens },
       ],
     });
 

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -1723,12 +1723,12 @@ export class SolanaStreamClient {
     if (!escrow?.data) {
       throw new Error("Couldn't get account info");
     }
-    const { mint, partner, senderTokens, escrowTokens } = decodeStream(escrow?.data);
+    const { mint, partner, senderTokens, escrowTokens, partnerFeePercent, streamflowFeePercent } = decodeStream(escrow?.data);
 
     const { mint: mintAccount, tokenProgramId } = await getMintAndProgram(this.connection, mint);
     const streamflowTreasuryTokens = await ata(mint, STREAMFLOW_TREASURY_PUBLIC_KEY, tokenProgramId);
     const partnerTokens = await ata(mint, partner, tokenProgramId);
-    const totalFee = await this.getTotalFee({ address: partner.toBase58() });
+    const totalFee = partnerFeePercent + streamflowFeePercent;
     const totalAmountToTransfer = calculateTotalAmountToDeposit(amount, totalFee);
 
     if (isNative) {

--- a/packages/stream/solana/StreamClient.ts
+++ b/packages/stream/solana/StreamClient.ts
@@ -1187,7 +1187,7 @@ export class SolanaStreamClient {
     const signedBatch: BatchItem[] = await signAllTransactionWithRecipients(sender, batch);
 
     if (prepareInstructions.length > 0) {
-      const prepareTx = signedBatch.shift();
+      const prepareTx = signedBatch.pop();
       await sendAndConfirmStreamRawTransaction(this.connection, prepareTx!, { hash, context }, this.schedulingParams);
     }
 


### PR DESCRIPTION
- fix: set correct owner for transfer hook account addition - the escrow token account is a PDA so it's also the owner;
- fix: use immutable fee percentages from the Contract for fee derivation during topup;
- fix: pop prepare tx from batch since it's added to the end of the array;